### PR TITLE
Add verbose networking logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ go run ./go_client -name "Agratis One" -pass demo
 The default server address is `server.deltatao.com:5010` and can be overridden
 with the `-host` flag.
 
-Pass `-dump` to log raw network traffic while debugging. When the server
+Pass `-dump` to log raw network traffic while debugging. Use `-verbose=false`
+to disable the default verbose logging of message summaries. When the server
 responds with `-30972` or `-30973`, the Go client will now fetch updated data
 files from the provided URL and reconnect automatically.
 

--- a/go_client/main.go
+++ b/go_client/main.go
@@ -53,6 +53,12 @@ func hexDump(prefix string, data []byte) {
 	fmt.Println(hex.Dump(data))
 }
 
+func vlog(format string, args ...interface{}) {
+	if verbose {
+		log.Printf(format, args...)
+	}
+}
+
 const (
 	kTypeVersion = 0x56657273 // 'Vers'
 )
@@ -102,6 +108,7 @@ func init() {
 }
 
 var dumpTraffic bool
+var verbose bool = true
 var ackFrame int32
 var resendFrame int32
 var commandNum uint32 = 1
@@ -213,6 +220,7 @@ func sendIdentifiers(conn net.Conn, clientVersion, imagesVersion, soundsVersion 
 	binary.BigEndian.PutUint32(buf[12:16], soundsVersion)
 	copy(buf[16:], data)
 	simpleEncrypt(buf[16:])
+	vlog("identifiers client=%d images=%d sounds=%d", clientVersion, imagesVersion, soundsVersion)
 	return sendMessage(conn, buf)
 }
 
@@ -223,6 +231,8 @@ func sendMessage(conn net.Conn, msg []byte) error {
 		return err
 	}
 	_, err := conn.Write(msg)
+	tag := binary.BigEndian.Uint16(msg[:2])
+	vlog("send tcp tag %d len %d", tag, len(msg))
 	hexDump("send", msg)
 	return err
 }
@@ -232,6 +242,8 @@ func sendUDPMessage(conn net.Conn, msg []byte) error {
 	binary.BigEndian.PutUint16(size[:], uint16(len(msg)))
 	buf := append(size[:], msg...)
 	_, err := conn.Write(buf)
+	tag := binary.BigEndian.Uint16(msg[:2])
+	vlog("send udp tag %d len %d", tag, len(msg))
 	hexDump("send", msg)
 	return err
 }
@@ -250,6 +262,8 @@ func readUDPMessage(conn net.Conn) ([]byte, error) {
 		return nil, fmt.Errorf("incomplete udp packet")
 	}
 	msg := append([]byte(nil), buf[2:2+sz]...)
+	tag := binary.BigEndian.Uint16(msg[:2])
+	vlog("recv udp tag %d len %d", tag, len(msg))
 	hexDump("recv", msg)
 	return msg, nil
 }
@@ -266,6 +280,7 @@ func sendPlayerInput(conn net.Conn) error {
 	binary.BigEndian.PutUint32(buf[16:20], commandNum)
 	buf[20] = 0
 	commandNum++
+	vlog("player input ack=%d resend=%d cmd=%d mouse=%d,%d", ackFrame, resendFrame, commandNum-1, mouseX, mouseY)
 	return sendUDPMessage(conn, buf)
 }
 
@@ -279,6 +294,8 @@ func readMessage(conn net.Conn) ([]byte, error) {
 	if _, err := io.ReadFull(conn, buf); err != nil {
 		return nil, err
 	}
+	tag := binary.BigEndian.Uint16(buf[:2])
+	vlog("recv tcp tag %d len %d", tag, len(buf))
 	hexDump("recv", buf)
 	return buf, nil
 }
@@ -472,6 +489,7 @@ func handleDrawState(m []byte) {
 	}
 	ackFrame = int32(binary.BigEndian.Uint32(data[1:5]))
 	resendFrame = int32(binary.BigEndian.Uint32(data[5:9]))
+	vlog("draw state ack=%d resend=%d", ackFrame, resendFrame)
 }
 
 func decodeMessage(m []byte) string {
@@ -513,6 +531,7 @@ func requestCharList(conn net.Conn, account, password string, challenge []byte, 
 	if err := sendMessage(conn, buf); err != nil {
 		return nil, err
 	}
+	vlog("request character list for %s", account)
 
 	resp, err := readMessage(conn)
 	if err != nil {
@@ -549,6 +568,7 @@ func requestCharList(conn net.Conn, account, password string, challenge []byte, 
 		names = append(names, string(namesData[:i]))
 		namesData = namesData[i+1:]
 	}
+	vlog("server returned %d characters", len(names))
 	return names, nil
 }
 
@@ -559,6 +579,7 @@ func main() {
 	listDemo := flag.Bool("list-demo", false, "list available demo characters")
 	clientVer := flag.Int("client-version", 1440, "client version number (kVersionNumber)")
 	flag.BoolVar(&dumpTraffic, "dump", false, "dump raw network traffic")
+	flag.BoolVar(&verbose, "verbose", true, "enable verbose logging")
 	flag.Parse()
 
 	autoDemo := *name == "demo" && *pass == "demo" && !*listDemo


### PR DESCRIPTION
## Summary
- add `-verbose` flag enabled by default
- log message summaries for TCP/UDP send and receive
- log struct values in key networking functions
- document verbose flag in README

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688c05b0ef48832a8d5ff2e37f80990a