### PR TITLE
Auto use baseline version when assets missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ go run ./go_client -client-version 1353
 The value passed should be the desired `kVersionNumber`.  Older versions
 cause the server to send the associated images and sound archives before
 reconnecting.
+The Go client automatically falls back to this baseline version when it detects missing image or sound data.

--- a/go_client/main.go
+++ b/go_client/main.go
@@ -45,6 +45,8 @@ func encodeFullVersion(v int) uint32 {
 	return uint32(v) << 8
 }
 
+const baseVersion = 1353
+
 func hexDump(prefix string, data []byte) {
 	if !dumpTraffic {
 		return
@@ -595,7 +597,7 @@ func main() {
 
 		sendVersion := clientVersion
 		if imagesMissing || soundsMissing {
-			sendVersion = clientVersion - 1
+			sendVersion = baseVersion - 1
 		}
 
 		tcpConn, err := net.Dial("tcp", *host)


### PR DESCRIPTION
## Summary
- automatically fall back to the baseline client version (1353) when image or sound data is missing
- document the automatic fallback behavior in README

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688c055de95c832abce9bd15a996df81