### PR TITLE
Add Ebiten-based draw state preview

### DIFF
--- a/go_client/go.mod
+++ b/go_client/go.mod
@@ -1,3 +1,14 @@
 module go_client
 
 go 1.24.3
+
+require github.com/hajimehoshi/ebiten/v2 v2.8.8
+
+require (
+	github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325 // indirect
+	github.com/ebitengine/hideconsole v1.0.0 // indirect
+	github.com/ebitengine/purego v0.8.0 // indirect
+	github.com/jezek/xgb v1.1.1 // indirect
+	golang.org/x/sync v0.8.0 // indirect
+	golang.org/x/sys v0.25.0 // indirect
+)

--- a/go_client/go.sum
+++ b/go_client/go.sum
@@ -1,0 +1,16 @@
+github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325 h1:Gk1XUEttOk0/hb6Tq3WkmutWa0ZLhNn/6fc6XZpM7tM=
+github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325/go.mod h1:ulhSQcbPioQrallSuIzF8l1NKQoD7xmMZc5NxzibUMY=
+github.com/ebitengine/hideconsole v1.0.0 h1:5J4U0kXF+pv/DhiXt5/lTz0eO5ogJ1iXb8Yj1yReDqE=
+github.com/ebitengine/hideconsole v1.0.0/go.mod h1:hTTBTvVYWKBuxPr7peweneWdkUwEuHuB3C1R/ielR1A=
+github.com/ebitengine/purego v0.8.0 h1:JbqvnEzRvPpxhCJzJJ2y0RbiZ8nyjccVUrSM3q+GvvE=
+github.com/ebitengine/purego v0.8.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/hajimehoshi/ebiten/v2 v2.8.8 h1:xyMxOAn52T1tQ+j3vdieZ7auDBOXmvjUprSrxaIbsi8=
+github.com/hajimehoshi/ebiten/v2 v2.8.8/go.mod h1:durJ05+OYnio9b8q0sEtOgaNeBEQG7Yr7lRviAciYbs=
+github.com/jezek/xgb v1.1.1 h1:bE/r8ZZtSv7l9gk6nU0mYx51aXrvnyb44892TwSaqS4=
+github.com/jezek/xgb v1.1.1/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
+golang.org/x/image v0.20.0 h1:7cVCUjQwfL18gyBJOmYvptfSHS8Fb3YUDtfLIZ7Nbpw=
+golang.org/x/image v0.20.0/go.mod h1:0a88To4CYVBAHp5FXJm8o7QbUl37Vd85ply1vyD8auM=
+golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
+golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/go_client/main.go
+++ b/go_client/main.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"image/color"
 	"io"
 	"log"
 	"math/rand"
@@ -23,11 +24,148 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 )
 
 var mouseX, mouseY = uint16(rand.Intn(1600)), uint16(rand.Intn(1200))
+
+type drawState struct {
+	descriptors []frameDescriptor
+	pictures    []framePicture
+	mobiles     []frameMobile
+}
+
+var (
+	state   drawState
+	stateMu sync.Mutex
+)
+
+var gameCtx context.Context
+
+type Game struct{}
+
+func (g *Game) Update() error {
+	select {
+	case <-gameCtx.Done():
+		return fmt.Errorf("context done")
+	default:
+	}
+	return nil
+}
+
+func (g *Game) Draw(screen *ebiten.Image) {
+	screen.Fill(color.White)
+	stateMu.Lock()
+	mobiles := append([]frameMobile(nil), state.mobiles...)
+	stateMu.Unlock()
+	for _, m := range mobiles {
+		x := int(m.H) + 320
+		y := int(m.V) + 240
+		ebitenutil.DrawRect(screen, float64(x), float64(y), 10, 10, color.RGBA{0xff, 0, 0, 0xff})
+	}
+	ebitenutil.DebugPrint(screen, fmt.Sprintf("mobiles: %d", len(mobiles)))
+}
+
+func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
+	return 640, 480
+}
+
+func runGame(ctx context.Context) {
+	gameCtx = ctx
+	ebiten.SetWindowSize(640, 480)
+	ebiten.SetWindowTitle("Draw State")
+	if err := ebiten.RunGame(&Game{}); err != nil {
+		log.Printf("ebiten: %v", err)
+	}
+}
+
+func sendInputLoop(ctx context.Context, conn net.Conn) {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		if err := sendPlayerInput(conn); err != nil {
+			fmt.Printf("send player input: %v\n", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func udpReadLoop(ctx context.Context, conn net.Conn) {
+	for {
+		if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+			fmt.Printf("udp deadline: %v\n", err)
+			return
+		}
+		m, err := readUDPMessage(conn)
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					continue
+				}
+			}
+			fmt.Printf("udp read error: %v\n", err)
+			return
+		}
+		tag := binary.BigEndian.Uint16(m[:2])
+		if tag == 2 { // kMsgDrawState
+			handleDrawState(m)
+		}
+		if txt := decodeMessage(m); txt != "" {
+			fmt.Println(txt)
+		} else {
+			fmt.Printf("udp msg tag %d len %d\n", tag, len(m))
+		}
+	}
+}
+
+func tcpReadLoop(ctx context.Context, conn net.Conn) {
+loop:
+	for {
+		if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+			fmt.Printf("set read deadline: %v\n", err)
+			break
+		}
+		m, err := readMessage(conn)
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				select {
+				case <-ctx.Done():
+					break loop
+				default:
+					continue
+				}
+			}
+			fmt.Printf("read error: %v\n", err)
+			break
+		}
+		tag := binary.BigEndian.Uint16(m[:2])
+		if tag == 2 { // kMsgDrawState
+			handleDrawState(m)
+		}
+		if txt := decodeMessage(m); txt != "" {
+			fmt.Println(txt)
+		} else {
+			fmt.Printf("msg tag %d len %d\n", tag, len(m))
+		}
+		select {
+		case <-ctx.Done():
+			break loop
+		default:
+		}
+	}
+}
 
 func simpleEncrypt(data []byte) {
 	key := []byte{0x3c, 0x5a, 0x69, 0x93, 0xa5, 0xc6}
@@ -587,13 +725,13 @@ func handleDrawState(m []byte) {
 	if len(data) < p+7 {
 		return
 	}
-	hp := data[p]
-	hpMax := data[p+1]
-	sp := data[p+2]
-	spMax := data[p+3]
-	bal := data[p+4]
-	balMax := data[p+5]
-	light := data[p+6]
+	_ = data[p]   // hp
+	_ = data[p+1] // hpMax
+	_ = data[p+2] // sp
+	_ = data[p+3] // spMax
+	_ = data[p+4] // bal
+	_ = data[p+5] // balMax
+	_ = data[p+6] // light
 	p += 7
 
 	if len(data) <= p {
@@ -643,6 +781,12 @@ func handleDrawState(m []byte) {
 	}
 
 	stateData := data[p:]
+
+	stateMu.Lock()
+	state.descriptors = descs
+	state.pictures = pics
+	state.mobiles = mobiles
+	stateMu.Unlock()
 
 	dlog("draw state cmd=%d ack=%d resend=%d desc=%d pict=%d again=%d mobile=%d state=%d", ackCmd, ackFrame, resendFrame, len(descs), len(pics), pictAgain, len(mobiles), len(stateData))
 
@@ -913,92 +1057,17 @@ func main() {
 		if result == 0 {
 			fmt.Println("login succeeded, reading messages (Ctrl-C to quit)...")
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-			defer stop()
 
 			if err := sendPlayerInput(udpConn); err != nil {
 				fmt.Printf("send player input: %v\n", err)
 			}
 
-			go func() {
-				ticker := time.NewTicker(2 * time.Second)
-				defer ticker.Stop()
-				for {
-					if err := sendPlayerInput(udpConn); err != nil {
-						fmt.Printf("send player input: %v\n", err)
-					}
-					select {
-					case <-ctx.Done():
-						return
-					case <-ticker.C:
-					}
-				}
-			}()
+			go sendInputLoop(ctx, udpConn)
+			go udpReadLoop(ctx, udpConn)
+			go tcpReadLoop(ctx, tcpConn)
 
-			go func() {
-				for {
-					if err := udpConn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
-						fmt.Printf("udp deadline: %v\n", err)
-						return
-					}
-					m, err := readUDPMessage(udpConn)
-					if err != nil {
-						if ne, ok := err.(net.Error); ok && ne.Timeout() {
-							select {
-							case <-ctx.Done():
-								return
-							default:
-								continue
-							}
-						}
-						fmt.Printf("udp read error: %v\n", err)
-						return
-					}
-					tag := binary.BigEndian.Uint16(m[:2])
-					if tag == 2 { // kMsgDrawState
-						handleDrawState(m)
-					}
-					if txt := decodeMessage(m); txt != "" {
-						fmt.Println(txt)
-					} else {
-						fmt.Printf("udp msg tag %d len %d\n", tag, len(m))
-					}
-				}
-			}()
-
-		loop:
-			for {
-				if err := tcpConn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
-					fmt.Printf("set read deadline: %v\n", err)
-					break
-				}
-				m, err := readMessage(tcpConn)
-				if err != nil {
-					if ne, ok := err.(net.Error); ok && ne.Timeout() {
-						select {
-						case <-ctx.Done():
-							break loop
-						default:
-							continue
-						}
-					}
-					fmt.Printf("read error: %v\n", err)
-					break
-				}
-				tag := binary.BigEndian.Uint16(m[:2])
-				if tag == 2 { // kMsgDrawState
-					handleDrawState(m)
-				}
-				if txt := decodeMessage(m); txt != "" {
-					fmt.Println(txt)
-				} else {
-					fmt.Printf("msg tag %d len %d\n", tag, len(m))
-				}
-				select {
-				case <-ctx.Done():
-					break loop
-				default:
-				}
-			}
+			runGame(ctx)
+			stop()
 			tcpConn.Close()
 			udpConn.Close()
 		}


### PR DESCRIPTION
## Summary
- set up ebiten dependency
- parse draw state into a global variable
- use ebiten to show a white window with debug boxes and text
- drive network loops and ebiten concurrently

## Testing
- `go vet`
- `go build`


------
https://chatgpt.com/codex/tasks/task_e_688c16e5bc14832a95d79b80fde3bf20