### PR TITLE
Improve draw state logging and background

### DIFF
--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -75,7 +75,9 @@ func handleDrawState(m []byte) {
 	}
 
 	simpleEncrypt(data)
-	parseDrawState(data)
+	if !parseDrawState(data) {
+		dlog("failed to parse draw state: % x", data[:16])
+	}
 }
 
 // parseDrawState decodes the draw state data. It returns false when the packet

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -45,7 +45,7 @@ func (g *Game) Update() error {
 }
 
 func (g *Game) Draw(screen *ebiten.Image) {
-	screen.Fill(color.White)
+	screen.Fill(color.RGBA{0xe0, 0xe0, 0xe0, 0xff})
 
 	stateMu.Lock()
 	descs := append([]frameDescriptor(nil), state.descriptors...)


### PR DESCRIPTION
## Summary
- tweak Ebiten background to light gray so objects show up
- log failures parsing draw state packets for easier debugging

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688c22515690832a87a735ea32832319