### PR TITLE
Display recent messages in window and use real mouse coordinates

### DIFF
--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -199,8 +199,10 @@ func parseDrawState(data []byte) bool {
 
 	if txt := decodeBEPP(stateData); txt != "" {
 		fmt.Println(txt)
+		addMessage(txt)
 	} else if txt := decodeBubble(stateData); txt != "" {
 		fmt.Println(txt)
+		addMessage(txt)
 	}
 	return true
 }

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"image/color"
 	"log"
-	"math/rand"
 	"net"
 	"sync"
 	"time"
@@ -17,7 +16,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 )
 
-var mouseX, mouseY = uint16(rand.Intn(1600)), uint16(rand.Intn(1200))
+var mouseX, mouseY uint16
 
 var gameCtx context.Context
 
@@ -44,6 +43,9 @@ func (g *Game) Update() error {
 		return fmt.Errorf("context done")
 	default:
 	}
+	x, y := ebiten.CursorPosition()
+	mouseX = uint16(x)
+	mouseY = uint16(y)
 	return nil
 }
 
@@ -82,6 +84,12 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	}
 	ebitenutil.DebugPrintAt(screen, strings.Join(lines, "\n"), 4, 4)
 	ebitenutil.DebugPrintAt(screen, fmt.Sprintf("desc:%d pict:%d mobile:%d", len(descs), len(pics), len(mobiles)), 4, 460)
+
+	msgs := getMessages()
+	startY := 480 - 12*len(msgs)
+	for i, msg := range msgs {
+		ebitenutil.DebugPrintAt(screen, msg, 4, startY+12*i)
+	}
 }
 
 func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
@@ -137,6 +145,7 @@ func udpReadLoop(ctx context.Context, conn net.Conn) {
 		}
 		if txt := decodeMessage(m); txt != "" {
 			fmt.Println(txt)
+			addMessage(txt)
 		} else {
 			fmt.Printf("udp msg tag %d len %d\n", tag, len(m))
 		}
@@ -169,6 +178,7 @@ loop:
 		}
 		if txt := decodeMessage(m); txt != "" {
 			fmt.Println(txt)
+			addMessage(txt)
 		} else {
 			fmt.Printf("msg tag %d len %d\n", tag, len(m))
 		}

--- a/go_client/messages.go
+++ b/go_client/messages.go
@@ -1,0 +1,25 @@
+package main
+
+import "sync"
+
+const maxMessages = 5
+
+var (
+	messageMu sync.Mutex
+	messages  []string
+)
+
+func addMessage(msg string) {
+	messageMu.Lock()
+	defer messageMu.Unlock()
+	messages = append(messages, msg)
+	if len(messages) > maxMessages {
+		messages = messages[len(messages)-maxMessages:]
+	}
+}
+
+func getMessages() []string {
+	messageMu.Lock()
+	defer messageMu.Unlock()
+	return append([]string(nil), messages...)
+}


### PR DESCRIPTION
## Summary
- track recent messages in a new message buffer
- display those messages at the bottom of the screen
- capture real mouse coordinates in game update loop
- forward messages from network handlers to the on-screen log

## Testing
- `go test ./...` *(fails: `collect2: error: ld returned 1 exit status`)*

------
https://chatgpt.com/codex/tasks/task_e_688c3154e498832ab7ead5dec17b2c77