### PR TITLE
Add on-demand image rendering

### DIFF
--- a/go_client/drawstate_test.go
+++ b/go_client/drawstate_test.go
@@ -13,7 +13,7 @@ type logMessage struct {
 }
 
 func TestParseDrawStateFromLogs(t *testing.T) {
-	f, err := os.Open("go_client/testdata/draw_state.json")
+	f, err := os.Open("testdata/draw_state.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -54,8 +54,10 @@ func (g *Game) Draw(screen *ebiten.Image) {
 
 	stateMu.Lock()
 	descs := make([]frameDescriptor, 0, len(state.descriptors))
-	for _, d := range state.descriptors {
+	descMap := make(map[uint8]frameDescriptor, len(state.descriptors))
+	for idx, d := range state.descriptors {
 		descs = append(descs, d)
+		descMap[idx] = d
 	}
 	pics := append([]framePicture(nil), state.pictures...)
 	mobiles := make([]frameMobile, 0, len(state.mobiles))
@@ -67,14 +69,30 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	for _, p := range pics {
 		x := int(p.H) + 320
 		y := int(p.V) + 240
-		ebitenutil.DrawRect(screen, float64(x)-2, float64(y)-2, 4, 4, color.RGBA{0, 0, 0xff, 0xff})
+		if img := loadImage(p.PictID); img != nil {
+			op := &ebiten.DrawImageOptions{}
+			op.GeoM.Translate(float64(x), float64(y))
+			screen.DrawImage(img, op)
+		} else {
+			ebitenutil.DrawRect(screen, float64(x)-2, float64(y)-2, 4, 4, color.RGBA{0, 0, 0xff, 0xff})
+		}
 		ebitenutil.DebugPrintAt(screen, fmt.Sprintf("%d", p.PictID), x+4, y-8)
 	}
 
 	for _, m := range mobiles {
 		x := int(m.H) + 320
 		y := int(m.V) + 240
-		ebitenutil.DrawRect(screen, float64(x)-3, float64(y)-3, 6, 6, color.RGBA{0xff, 0, 0, 0xff})
+		var img *ebiten.Image
+		if d, ok := descMap[m.Index]; ok {
+			img = loadImage(d.PictID)
+		}
+		if img != nil {
+			op := &ebiten.DrawImageOptions{}
+			op.GeoM.Translate(float64(x), float64(y))
+			screen.DrawImage(img, op)
+		} else {
+			ebitenutil.DrawRect(screen, float64(x)-3, float64(y)-3, 6, 6, color.RGBA{0xff, 0, 0, 0xff})
+		}
 		ebitenutil.DebugPrintAt(screen, fmt.Sprintf("%d", m.Index), x+6, y-8)
 	}
 

--- a/go_client/images.go
+++ b/go_client/images.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	_ "image/png"
+	"sync"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+)
+
+// imageCache lazily loads images from the img directory. The files are
+// expected to be named as <id>.png where <id> matches the picture ID sent by
+// the server. Loading errors are logged via dlog and result in a nil image.
+var (
+	imageCache = make(map[uint16]*ebiten.Image)
+	imageMu    sync.Mutex
+)
+
+// loadImage retrieves the image for the specified picture ID. Images are
+// cached after the first load to avoid reopening files each frame.
+func loadImage(id uint16) *ebiten.Image {
+	imageMu.Lock()
+	defer imageMu.Unlock()
+	if img, ok := imageCache[id]; ok {
+		return img
+	}
+	path := fmt.Sprintf("img/%d.png", id)
+	img, _, err := ebitenutil.NewImageFromFile(path)
+	if err != nil {
+		dlog("load %s: %v", path, err)
+		imageCache[id] = nil
+		return nil
+	}
+	imageCache[id] = img
+	return img
+}


### PR DESCRIPTION
## Summary
- support lazy loading of `img/<id>.png` images for draw state
- render picture and mobile images in the Ebiten window
- fix test file path so tests run inside module

## Testing
- `xvfb-run go test ./...` *(fails: parseDrawState failed)*

------
https://chatgpt.com/codex/tasks/task_e_688c33f96744832aa8ffc8f4b4e01eae