### PR TITLE
Filter short messages to reduce spam

### DIFF
--- a/go_client/decode.go
+++ b/go_client/decode.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"strings"
 
 	"golang.org/x/text/encoding/charmap"
 )
@@ -91,7 +92,10 @@ func decodeMessage(m []byte) string {
 		data = data[:i]
 	}
 	if len(data) > 0 {
-		return decodeMacRoman(data)
+		txt := decodeMacRoman(data)
+		if len([]rune(strings.TrimSpace(txt))) >= 4 {
+			return txt
+		}
 	}
 
 	simpleEncrypt(data)
@@ -105,7 +109,10 @@ func decodeMessage(m []byte) string {
 		data = data[:i]
 	}
 	if len(data) > 0 {
-		return decodeMacRoman(data)
+		txt := decodeMacRoman(data)
+		if len([]rune(strings.TrimSpace(txt))) >= 4 {
+			return txt
+		}
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary
- filter out bogus short messages when decoding text

## Testing
- `go test ./...` *(fails: GLFW requires a DISPLAY and isn't available)*

------
https://chatgpt.com/codex/tasks/task_e_688c3acd4d88832a853fbbbf24c8541d