### PR TITLE
Add simple clmov playback

### DIFF
--- a/go_client/main.go
+++ b/go_client/main.go
@@ -17,11 +17,28 @@ import (
 
 func main() {
 	host := flag.String("host", "server.deltatao.com:5010", "server address")
+	clmov := flag.String("clmov", "", "play back a .clMov file")
 	name := flag.String("name", "demo", "character name")
 	pass := flag.String("pass", "demo", "character password")
 	clientVer := flag.Int("client-version", 1440, "client version number (kVersionNumber)")
 	flag.BoolVar(&debug, "debug", true, "enable debug logging")
 	flag.Parse()
+
+	if *clmov != "" {
+		frames, err := parseMovie(*clmov)
+		if err != nil {
+			log.Fatalf("parse movie: %v", err)
+		}
+		for _, m := range frames {
+			if len(m) >= 2 && binary.BigEndian.Uint16(m[:2]) == 2 {
+				handleDrawState(m)
+			}
+			if txt := decodeMessage(m); txt != "" {
+				fmt.Println(txt)
+			}
+		}
+		return
+	}
 
 	if debug {
 		logName := fmt.Sprintf("debug-%s.log", time.Now().Format("20060102-150405"))

--- a/go_client/movie.go
+++ b/go_client/movie.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"os"
+)
+
+const movieSignature = 0xdeadbeef
+
+func parseMovie(path string) ([][]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) < 8 {
+		return nil, fmt.Errorf("short file")
+	}
+	if binary.BigEndian.Uint32(data[:4]) != movieSignature {
+		return nil, fmt.Errorf("bad signature")
+	}
+	headerLen := int(binary.BigEndian.Uint16(data[6:8]))
+	if headerLen <= 0 || headerLen > len(data) {
+		headerLen = 24
+	}
+	pos := headerLen
+	sign := []byte{0xde, 0xad, 0xbe, 0xef}
+	frames := [][]byte{}
+	for pos+12 <= len(data) {
+		if binary.BigEndian.Uint32(data[pos:pos+4]) != movieSignature {
+			idx := bytes.Index(data[pos:], sign)
+			if idx < 0 {
+				break
+			}
+			pos += idx
+			continue
+		}
+		frame := binary.BigEndian.Uint32(data[pos+4 : pos+8])
+		size := int(binary.BigEndian.Uint16(data[pos+8 : pos+10]))
+		flags := binary.BigEndian.Uint16(data[pos+10 : pos+12])
+		_ = frame
+		_ = flags
+		pos += 12
+		if size > 0 {
+			if pos+size > len(data) {
+				break
+			}
+			frames = append(frames, append([]byte(nil), data[pos:pos+size]...))
+			pos += size
+		} else {
+			idx := bytes.Index(data[pos:], sign)
+			if idx < 0 {
+				break
+			}
+			pos += idx
+		}
+	}
+	return frames, nil
+}

--- a/go_client/movie_test.go
+++ b/go_client/movie_test.go
@@ -1,0 +1,16 @@
+package main
+
+import "testing"
+
+func TestParseMovie(t *testing.T) {
+	frames, err := parseMovie("test.clMov")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frames) == 0 {
+		t.Fatalf("no frames parsed")
+	}
+	if len(frames[0]) == 0 {
+		t.Fatalf("first frame empty")
+	}
+}


### PR DESCRIPTION
## Summary
- add `parseMovie` to scan `.clMov` files
- add `-clmov` flag to play back movies instead of connecting to the server
- test parsing of `test.clMov`

## Testing
- `go test -run TestParseMovie -count=1`
- `go test ./... -count=1` *(fails: parseDrawState failed for message 0)*

------
https://chatgpt.com/codex/tasks/task_e_688c410f08a8832a9fbea8b50f5bd5a8