### PR TITLE
Add 5fps playback for clmov

### DIFF
--- a/go_client/main.go
+++ b/go_client/main.go
@@ -29,14 +29,28 @@ func main() {
 		if err != nil {
 			log.Fatalf("parse movie: %v", err)
 		}
-		for _, m := range frames {
-			if len(m) >= 2 && binary.BigEndian.Uint16(m[:2]) == 2 {
-				handleDrawState(m)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			ticker := time.NewTicker(200 * time.Millisecond)
+			defer ticker.Stop()
+			for _, m := range frames {
+				if len(m) >= 2 && binary.BigEndian.Uint16(m[:2]) == 2 {
+					handleDrawState(m)
+				}
+				if txt := decodeMessage(m); txt != "" {
+					fmt.Println(txt)
+				}
+				select {
+				case <-ticker.C:
+				case <-ctx.Done():
+					return
+				}
 			}
-			if txt := decodeMessage(m); txt != "" {
-				fmt.Println(txt)
-			}
-		}
+			cancel()
+		}()
+
+		runGame(ctx)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- render .clMov files using the ebiten renderer
- play back frames at 5 fps

## Testing
- `go test ./...` *(fails: exit status 1 during build)*

------
https://chatgpt.com/codex/tasks/task_e_688c468cbd8c832aa7db223506e4cef3