### PR TITLE
Fix CL_Images loading for movie playback

### DIFF
--- a/go_client/main.go
+++ b/go_client/main.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -31,6 +32,16 @@ func main() {
 	clImages, imgErr = climg.Load("CL_Images")
 	if imgErr != nil {
 		log.Printf("load CL_Images: %v", imgErr)
+	}
+	if imgErr != nil && *clmov != "" {
+		alt := filepath.Join(filepath.Dir(*clmov), "CL_Images")
+		if imgs, err := climg.Load(alt); err == nil {
+			clImages = imgs
+			imgErr = nil
+			log.Printf("loaded CL_Images from %s", alt)
+		} else {
+			log.Printf("load CL_Images from %s: %v", alt, err)
+		}
 	}
 
 	if *clmov != "" {


### PR DESCRIPTION
## Summary
- load CL_Images from the same folder as the `.clMov` file when the default load fails

## Testing
- `xvfb-run go test ./...` *(fails: parseDrawState failed for message 0)*

------
https://chatgpt.com/codex/tasks/task_e_688c4d7568a0832ab2bb014944e63f2e