### PR TITLE
Improve info text parsing

### DIFF
--- a/go_client/decode.go
+++ b/go_client/decode.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 
 	"golang.org/x/text/encoding/charmap"
@@ -115,4 +116,28 @@ func decodeMessage(m []byte) string {
 		}
 	}
 	return ""
+}
+
+func handleInfoText(data []byte) {
+	for _, line := range bytes.Split(data, []byte{'\r'}) {
+		if len(line) == 0 {
+			continue
+		}
+		if txt := decodeBEPP(line); txt != "" {
+			fmt.Println(txt)
+			addMessage(txt)
+			continue
+		}
+		if txt := decodeBubble(line); txt != "" {
+			fmt.Println(txt)
+			addMessage(txt)
+			continue
+		}
+		s := strings.TrimSpace(decodeMacRoman(line))
+		if s == "" || strings.HasPrefix(s, "/") {
+			continue
+		}
+		fmt.Println(s)
+		addMessage(s)
+	}
 }

--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"strings"
 )
 
@@ -211,17 +210,7 @@ func parseDrawState(data []byte) bool {
 		ackCmd, ackFrame, resendFrame, len(descs), len(pics), pictAgain, len(mobiles), len(stateData))
 
 	if idx := bytes.IndexByte(stateData, 0); idx >= 0 {
-		msgData := stateData[:idx]
-		if txt := decodeBEPP(msgData); txt != "" {
-			fmt.Println(txt)
-			addMessage(txt)
-		} else if txt := decodeBubble(msgData); txt != "" {
-			fmt.Println(txt)
-			addMessage(txt)
-		} else if s := strings.TrimSpace(decodeMacRoman(msgData)); s != "" {
-			fmt.Println(s)
-			addMessage(s)
-		}
+		handleInfoText(stateData[:idx])
 	}
 	return true
 }


### PR DESCRIPTION
## Summary
- add `handleInfoText` to decode each message line and skip command-like lines
- call the new handler when parsing draw state messages
- remove unused fmt import from draw.go

## Testing
- `go vet ./...` *(fails: `Xrandr.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c560df22c832a9414de8817bdadb7