### PR TITLE
Improve bubble decoding

### DIFF
--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 )
 
 // frameDescriptor describes an on-screen descriptor.
@@ -210,6 +211,46 @@ func parseDrawState(data []byte) bool {
 
 	if idx := bytes.IndexByte(stateData, 0); idx >= 0 {
 		handleInfoText(stateData[:idx])
+		stateData = stateData[idx+1:]
+	} else {
+		return true
+	}
+
+	if len(stateData) > 0 {
+		bubbleCount := int(stateData[0])
+		stateData = stateData[1:]
+		for i := 0; i < bubbleCount; i++ {
+			if len(stateData) < 2 {
+				return false
+			}
+			typ := int(stateData[1])
+			p := 2
+			if typ&kBubbleNotCommon != 0 {
+				if len(stateData) < p+1 {
+					return false
+				}
+				p++
+			}
+			if typ&kBubbleFar != 0 {
+				if len(stateData) < p+4 {
+					return false
+				}
+				p += 4
+			}
+			if len(stateData) < p {
+				return false
+			}
+			end := bytes.IndexByte(stateData[p:], 0)
+			if end < 0 {
+				return false
+			}
+			bubbleData := stateData[:p+end+1]
+			if txt := decodeBubble(bubbleData); txt != "" {
+				fmt.Println(txt)
+				addMessage(txt)
+			}
+			stateData = stateData[p+end+1:]
+		}
 	}
 	return true
 }

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -199,6 +199,7 @@ func udpReadLoop(ctx context.Context, conn net.Conn) {
 		tag := binary.BigEndian.Uint16(m[:2])
 		if tag == 2 { // kMsgDrawState
 			handleDrawState(m)
+			continue
 		}
 		if txt := decodeMessage(m); txt != "" {
 			fmt.Println(txt)
@@ -232,6 +233,7 @@ loop:
 		tag := binary.BigEndian.Uint16(m[:2])
 		if tag == 2 { // kMsgDrawState
 			handleDrawState(m)
+			continue
 		}
 		if txt := decodeMessage(m); txt != "" {
 			fmt.Println(txt)


### PR DESCRIPTION
## Summary
- parse bubble data from draw state messages
- skip decoding entire draw state packet when handling network input

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_688c598057bc832a9b8e356a27876778