### PR TITLE
Fix alpha blending for sprites

### DIFF
--- a/go_client/climg/climg.go
+++ b/go_client/climg/climg.go
@@ -293,6 +293,10 @@ func (c *CLImages) Get(id uint32) *ebiten.Image {
 		if idx == 0 && transparent {
 			a = 0
 		}
+		// Ebiten expects premultiplied alpha values.
+		r = uint8(int(r) * int(a) / 255)
+		g = uint8(int(g) * int(a) / 255)
+		b = uint8(int(b) * int(a) / 255)
 		img.SetRGBA(i%width, i/width, color.RGBA{r, g, b, a})
 	}
 


### PR DESCRIPTION
## Summary
- premultiply RGB values by alpha when decoding sprite images so Ebiten handles transparency correctly

## Testing
- `go vet ./...` *(fails: `X11/extensions/Xrandr.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_688c5d0633e4832ab533fb2b27b598b4