### PR TITLE
Fix text decoding for bubble messages

### DIFF
--- a/go_client/decode.go
+++ b/go_client/decode.go
@@ -73,6 +73,10 @@ func decodeBubble(data []byte) string {
 		return "yell: " + text
 	case kBubbleThought:
 		return "think: " + text
+	case kBubblePonder:
+		return "ponder: " + text
+	case kBubbleNarrate:
+		return "console: " + text
 	default:
 		return text
 	}

--- a/go_client/util.go
+++ b/go_client/util.go
@@ -95,10 +95,15 @@ var resendFrame int32
 var commandNum uint32 = 1
 
 const (
-	kBubbleNormal  = 0
-	kBubbleWhisper = 1
-	kBubbleYell    = 2
-	kBubbleThought = 3
+	kBubbleNormal       = 0
+	kBubbleWhisper      = 1
+	kBubbleYell         = 2
+	kBubbleThought      = 3
+	kBubbleRealAction   = 4
+	kBubbleMonster      = 5
+	kBubblePlayerAction = 6
+	kBubblePonder       = 7
+	kBubbleNarrate      = 8
 
 	kBubbleTypeMask  = 0x3F
 	kBubbleNotCommon = 0x40


### PR DESCRIPTION
## Summary
- add constants for all bubble types including ponder and narrate
- decode ponder and console-style (narrate) bubbles

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_688c5d5c6778832aa360c1b9dd55929f