### PR TITLE
Fix empty bubble text and tweak message area

### DIFF
--- a/go_client/decode.go
+++ b/go_client/decode.go
@@ -25,7 +25,10 @@ func decodeBEPP(data []byte) string {
 	if i := bytes.IndexByte(textBytes, 0); i >= 0 {
 		textBytes = textBytes[:i]
 	}
-	text := decodeMacRoman(textBytes)
+	text := strings.TrimSpace(decodeMacRoman(textBytes))
+	if text == "" {
+		return ""
+	}
 	switch prefix {
 	case "th":
 		return "think: " + text
@@ -63,7 +66,10 @@ func decodeBubble(data []byte) string {
 	if i := bytes.IndexByte(msgData, 0); i >= 0 {
 		msgData = msgData[:i]
 	}
-	text := decodeMacRoman(msgData)
+	text := strings.TrimSpace(decodeMacRoman(msgData))
+	if text == "" {
+		return ""
+	}
 	switch typ & kBubbleTypeMask {
 	case kBubbleNormal:
 		return "say: " + text

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -143,7 +143,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	//ebitenutil.DebugPrintAt(screen, fmt.Sprintf("desc:%d pict:%d mobile:%d", len(descs), len(pics), len(mobiles)), 490, 460)
 
 	msgs := getMessages()
-	startY := 480 - 12*len(msgs)
+	startY := 480 - 12*len(msgs) - 6
 	for i, msg := range msgs {
 		ebitenutil.DebugPrintAt(screen, msg, 4, startY+12*i)
 	}


### PR DESCRIPTION
## Summary
- ignore empty text when decoding bubble and BEPP messages
- move on-screen messages up a bit

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688c5fbfea40832ab724efe08f4ab888