### PR TITLE
Filter out self messages

### DIFF
--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -112,6 +112,9 @@ func parseDrawState(data []byte) bool {
 		if idx := bytes.IndexByte(data[p:], 0); idx >= 0 {
 			d.Name = string(data[p : p+idx])
 			p += idx + 1
+			if d.Name == playerName {
+				playerIndex = d.Index
+			}
 		} else {
 			return false
 		}
@@ -223,6 +226,7 @@ func parseDrawState(data []byte) bool {
 			if len(stateData) < 2 {
 				return false
 			}
+			idx := stateData[0]
 			typ := int(stateData[1])
 			p := 2
 			if typ&kBubbleNotCommon != 0 {
@@ -247,7 +251,9 @@ func parseDrawState(data []byte) bool {
 			bubbleData := stateData[:p+end+1]
 			if txt := decodeBubble(bubbleData); txt != "" {
 				fmt.Println(txt)
-				addMessage(txt)
+				if idx != playerIndex {
+					addMessage(txt)
+				}
 			}
 			stateData = stateData[p+end+1:]
 		}

--- a/go_client/main.go
+++ b/go_client/main.go
@@ -178,6 +178,7 @@ func main() {
 			*name = names[rand.Intn(len(names))]
 			fmt.Println("selected demo character:", *name)
 		}
+		playerName = *name
 
 		answer, err := answerChallenge(*pass, challenge)
 		if err != nil {

--- a/go_client/util.go
+++ b/go_client/util.go
@@ -93,6 +93,8 @@ var logFile *os.File
 var ackFrame int32
 var resendFrame int32
 var commandNum uint32 = 1
+var playerName string
+var playerIndex uint8 = 0xff
 
 const (
 	kBubbleNormal       = 0


### PR DESCRIPTION
## Summary
- add `playerName` and `playerIndex`
- track own descriptor index while parsing draw state
- skip message logging when the message comes from the main player

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_688c62534684832a8029d90342dc8abd