### PR TITLE
Fix draw order using picture planes

### DIFF
--- a/go_client/climg/climg.go
+++ b/go_client/climg/climg.go
@@ -23,6 +23,7 @@ type dataLocation struct {
 	imageID    uint32
 	colorID    uint32
 	flags      uint32
+	plane      int16
 	numFrames  uint16
 }
 
@@ -138,6 +139,7 @@ func Load(path string) (*CLImages, error) {
 		if err := binary.Read(r, binary.BigEndian, &plane); err != nil {
 			return nil, err
 		}
+		ref.plane = plane
 		if err := binary.Read(r, binary.BigEndian, &ref.numFrames); err != nil {
 			return nil, err
 		}
@@ -314,4 +316,13 @@ func (c *CLImages) NumFrames(id uint32) int {
 		return int(ref.numFrames)
 	}
 	return 1
+}
+
+// Plane returns the drawing plane for the given image ID. If unknown, it
+// returns 0.
+func (c *CLImages) Plane(id uint32) int {
+	if ref := c.idrefs[id]; ref != nil {
+		return int(ref.plane)
+	}
+	return 0
 }

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -69,7 +69,18 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	}
 	stateMu.Unlock()
 
-	sort.Slice(pics, func(i, j int) bool { return pics[i].V < pics[j].V })
+	sort.Slice(pics, func(i, j int) bool {
+		pi := 0
+		pj := 0
+		if clImages != nil {
+			pi = clImages.Plane(uint32(pics[i].PictID))
+			pj = clImages.Plane(uint32(pics[j].PictID))
+		}
+		if pi == pj {
+			return pics[i].V < pics[j].V
+		}
+		return pi < pj
+	})
 
 	dead := make([]frameMobile, 0, len(mobiles))
 	live := make([]frameMobile, 0, len(mobiles))
@@ -79,7 +90,6 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		}
 		live = append(live, m)
 	}
-	sort.Slice(live, func(i, j int) bool { return live[i].V < live[j].V })
 
 	type textItem struct {
 		x, y int
@@ -121,17 +131,32 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		drawMobile(m)
 	}
 
-	i, j := 0, 0
-	for i < len(live) || j < len(pics) {
-		if j >= len(pics) || (i < len(live) && live[i].V < pics[j].V) {
-			if live[i].State != poseDead {
-				drawMobile(live[i])
-			}
-			i++
-		} else {
-			drawPicture(pics[j])
-			j++
+	split := 0
+	for split < len(pics) {
+		plane := 0
+		if clImages != nil {
+			plane = clImages.Plane(uint32(pics[split].PictID))
 		}
+		if plane >= 0 {
+			break
+		}
+		split++
+	}
+
+	for _, p := range pics[:split] {
+		drawPicture(p)
+	}
+
+	sort.Slice(live, func(i, j int) bool { return live[i].V < live[j].V })
+
+	for _, m := range live {
+		if m.State != poseDead {
+			drawMobile(m)
+		}
+	}
+
+	for _, p := range pics[split:] {
+		drawPicture(p)
 	}
 
 	/*


### PR DESCRIPTION
## Summary
- preserve picture plane info when loading CL_Images
- expose the plane value via `climg.CLImages.Plane`
- sort pictures by plane in game renderer
- draw background pictures, then mobiles, then foreground pictures

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_688c6d296834832a9e6915aea77f7d82