### PR TITLE
Fix mobile frame rendering

### DIFF
--- a/go_client/game.go
+++ b/go_client/game.go
@@ -102,10 +102,10 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		y := int(m.V) + fieldCenterY
 		var img *ebiten.Image
 		if d, ok := descMap[m.Index]; ok {
-			img = loadImage(d.PictID)
+			img = loadMobileFrame(d.PictID, m.State)
 		}
 		if img != nil {
-			size := img.Bounds().Dx() / 16
+			size := img.Bounds().Dx()
 			op := &ebiten.DrawImageOptions{}
 			op.GeoM.Translate(float64(x-size/2), float64(y-size/2))
 			screen.DrawImage(img, op)
@@ -129,35 +129,64 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		texts = append(texts, textItem{x + 4, y - 8, fmt.Sprintf("%d", p.PictID)})
 	}
 
+	// sort pictures by plane and split them into negative, zero and positive planes
+	negPics := make([]framePicture, 0)
+	zeroPics := make([]framePicture, 0)
+	posPics := make([]framePicture, 0)
+	for _, p := range pics {
+		plane := 0
+		if clImages != nil {
+			plane = clImages.Plane(uint32(p.PictID))
+		}
+		switch {
+		case plane < 0:
+			negPics = append(negPics, p)
+		case plane == 0:
+			zeroPics = append(zeroPics, p)
+		default:
+			posPics = append(posPics, p)
+		}
+	}
+
+	// draw pictures below mobiles
+	for _, p := range negPics {
+		drawPicture(p)
+	}
+
+	// draw fallen mobiles before merging
+	sort.Slice(dead, func(i, j int) bool { return dead[i].V < dead[j].V })
 	for _, m := range dead {
 		drawMobile(m)
 	}
 
-	split := 0
-	for split < len(pics) {
-		plane := 0
-		if clImages != nil {
-			plane = clImages.Plane(uint32(pics[split].PictID))
-		}
-		if plane >= 0 {
-			break
-		}
-		split++
-	}
-
-	for _, p := range pics[:split] {
-		drawPicture(p)
-	}
-
 	sort.Slice(live, func(i, j int) bool { return live[i].V < live[j].V })
 
-	for _, m := range live {
-		if m.State != poseDead {
-			drawMobile(m)
+	// merge plane 0 pictures with living mobiles by vertical coordinate
+	i, j := 0, 0
+	for i < len(live) || j < len(zeroPics) {
+		var mV, pV int
+		if i < len(live) {
+			mV = int(live[i].V)
+		} else {
+			mV = int(^uint(0) >> 1) // max int
+		}
+		if j < len(zeroPics) {
+			pV = int(zeroPics[j].V)
+		} else {
+			pV = int(^uint(0) >> 1)
+		}
+		if mV < pV {
+			if live[i].State != poseDead {
+				drawMobile(live[i])
+			}
+			i++
+		} else {
+			drawPicture(zeroPics[j])
+			j++
 		}
 	}
 
-	for _, p := range pics[split:] {
+	for _, p := range posPics {
 		drawPicture(p)
 	}
 

--- a/go_client/images.go
+++ b/go_client/images.go
@@ -13,38 +13,108 @@ import (
 // imageCache lazily loads images from the CL_Images archive. If an image is not
 // present, nil is cached to avoid repeated lookups.
 var (
+	// imageCache holds a cropped version of the first frame of an image. It
+	// is used for static pictures on the playfield.
 	imageCache = make(map[uint16]*ebiten.Image)
-	imageMu    sync.Mutex
-	clImages   *climg.CLImages
+	// sheetCache holds the full sprite sheet for a picture ID. These are
+	// used when extracting individual mobile frames.
+	sheetCache = make(map[uint16]*ebiten.Image)
+	// mobileCache caches individual mobile frames keyed by picture ID and
+	// state.
+	mobileCache = make(map[uint32]*ebiten.Image)
+
+	imageMu  sync.Mutex
+	clImages *climg.CLImages
 )
 
 // loadImage retrieves the image for the specified picture ID. Images are
 // cached after the first load to avoid reopening files each frame.
-func loadImage(id uint16) *ebiten.Image {
+// loadSheet retrieves the full sprite sheet for the specified picture ID.
+func loadSheet(id uint16) *ebiten.Image {
 	imageMu.Lock()
-	defer imageMu.Unlock()
-	if img, ok := imageCache[id]; ok {
+	if img, ok := sheetCache[id]; ok {
+		imageMu.Unlock()
 		return img
 	}
+	imageMu.Unlock()
+
 	if clImages != nil {
 		if img := clImages.Get(uint32(id)); img != nil {
-			frames := clImages.NumFrames(uint32(id))
-			if frames > 1 {
-				frame := 9
-				if frame >= frames {
-					frame = 0
-				}
-				h := img.Bounds().Dy() / frames
-				y0 := frame * h
-				img = img.SubImage(image.Rect(0, y0, img.Bounds().Dx(), y0+h)).(*ebiten.Image)
-			}
-			imageCache[id] = img
+			imageMu.Lock()
+			sheetCache[id] = img
+			imageMu.Unlock()
 			return img
 		}
 		log.Printf("missing image %d", id)
 	} else {
 		log.Printf("CL_Images not loaded when requesting image %d", id)
 	}
-	imageCache[id] = nil
+
+	imageMu.Lock()
+	sheetCache[id] = nil
+	imageMu.Unlock()
 	return nil
+}
+
+// loadImage retrieves the first frame for the specified picture ID. Images are
+// cached after the first load to avoid reopening files each frame.
+func loadImage(id uint16) *ebiten.Image {
+	imageMu.Lock()
+	if img, ok := imageCache[id]; ok {
+		imageMu.Unlock()
+		return img
+	}
+	imageMu.Unlock()
+
+	if sheet := loadSheet(id); sheet != nil {
+		frames := clImages.NumFrames(uint32(id))
+		if frames > 1 {
+			h := sheet.Bounds().Dy() / frames
+			sheet = sheet.SubImage(image.Rect(0, 0, sheet.Bounds().Dx(), h)).(*ebiten.Image)
+		}
+		imageMu.Lock()
+		imageCache[id] = sheet
+		imageMu.Unlock()
+		return sheet
+	}
+
+	imageMu.Lock()
+	imageCache[id] = nil
+	imageMu.Unlock()
+	return nil
+}
+
+// loadMobileFrame retrieves a cropped frame from a mobile sprite sheet based on
+// the state value provided by the server.
+func loadMobileFrame(id uint16, state uint8) *ebiten.Image {
+	key := uint32(id)<<8 | uint32(state)
+	imageMu.Lock()
+	if img, ok := mobileCache[key]; ok {
+		imageMu.Unlock()
+		return img
+	}
+	imageMu.Unlock()
+
+	sheet := loadSheet(id)
+	if sheet == nil {
+		imageMu.Lock()
+		mobileCache[key] = nil
+		imageMu.Unlock()
+		return nil
+	}
+
+	size := sheet.Bounds().Dx() / 16
+	x := int(state&0x0F) * size
+	y := int(state>>4) * size
+	if x+size > sheet.Bounds().Dx() || y+size > sheet.Bounds().Dy() {
+		imageMu.Lock()
+		mobileCache[key] = nil
+		imageMu.Unlock()
+		return nil
+	}
+	frame := sheet.SubImage(image.Rect(x, y, x+size, y+size)).(*ebiten.Image)
+	imageMu.Lock()
+	mobileCache[key] = frame
+	imageMu.Unlock()
+	return frame
 }


### PR DESCRIPTION
## Summary
- load full sprite sheets for mobile frames
- add `loadMobileFrame` to crop the correct mobile pose
- adjust draw order to interleave mobiles with plane 0 pictures

## Testing
- `gofmt -w go_client/images.go go_client/game.go`
- `go vet ./...` *(fails: X11 headers missing)*
- `go build ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_688c71e62c38832ab5b8ee90efb02858