### PR TITLE
Improve interpolation timing

### DIFF
--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -211,8 +211,15 @@ func parseDrawState(data []byte) bool {
 	for idx, m := range state.mobiles {
 		state.prevMobiles[idx] = m
 	}
-	state.prevTime = state.curTime
-	state.curTime = time.Now()
+	const defaultInterval = time.Second / 5
+	interval := defaultInterval
+	if !state.prevTime.IsZero() && !state.curTime.IsZero() {
+		if d := state.curTime.Sub(state.prevTime); d > 0 {
+			interval = d
+		}
+	}
+	state.prevTime = time.Now()
+	state.curTime = state.prevTime.Add(interval)
 
 	if state.mobiles == nil {
 		state.mobiles = make(map[uint8]frameMobile)


### PR DESCRIPTION
## Summary
- tweak timestamp logic for smoother interpolation

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688c774c95d0832a946eda266763ae4b