### PR TITLE
Handle clmov metadata frames

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,12 @@ This repo includes a minimal Go client under `go_client/`. To build or run the G
    go mod download
    ```
 
+For convenience the `scripts` directory contains small helper scripts:
+`scripts/build_go_client.sh` fetches dependencies, formats the sources and
+compiles the client. `scripts/run_go_client.sh` launches the program.
+
+Both scripts expect to be executed from the repository root.
+
 ## Build steps
 1. Navigate to the `go_client` directory if not already there:
    ```bash
@@ -27,10 +33,13 @@ This repo includes a minimal Go client under `go_client/`. To build or run the G
    go build
    ```
    This produces the executable `go_client` in the current directory.
+   You can also run `../scripts/build_go_client.sh` from the repo root which
+   runs `go mod download` and `go build ./...` in one step.
 3. You can also run the program directly with:
    ```bash
    go run .
    ```
+   Alternatively run `../scripts/run_go_client.sh` from the repo root.
 
 The module path is `go_client` and the main package is located in this directory.
 

--- a/go_client/movie.go
+++ b/go_client/movie.go
@@ -7,6 +7,13 @@ import (
 	"os"
 )
 
+const (
+	flagStale        = 0x01
+	flagMobileData   = 0x02
+	flagGameState    = 0x04
+	flagPictureTable = 0x08
+)
+
 const movieSignature = 0xdeadbeef
 
 func parseMovie(path string) ([][]byte, error) {
@@ -27,6 +34,7 @@ func parseMovie(path string) ([][]byte, error) {
 	pos := headerLen
 	sign := []byte{0xde, 0xad, 0xbe, 0xef}
 	frames := [][]byte{}
+	frameNum := 0
 	for pos+12 <= len(data) {
 		if binary.BigEndian.Uint32(data[pos:pos+4]) != movieSignature {
 			idx := bytes.Index(data[pos:], sign)
@@ -39,9 +47,90 @@ func parseMovie(path string) ([][]byte, error) {
 		frame := binary.BigEndian.Uint32(data[pos+4 : pos+8])
 		size := int(binary.BigEndian.Uint16(data[pos+8 : pos+10]))
 		flags := binary.BigEndian.Uint16(data[pos+10 : pos+12])
-		_ = frame
-		_ = flags
+		dlog("frame %d index=%d size=%d flags=0x%x", frameNum, frame, size, flags)
 		pos += 12
+		if flags&flagGameState != 0 {
+			dlog("GameState block at %d", pos)
+			if pos+24 > len(data) {
+				break
+			}
+			maxSize := int(binary.BigEndian.Uint32(data[pos+12 : pos+16]))
+			pos += 24 + maxSize
+			continue
+		}
+		if flags&flagMobileData != 0 {
+			dlog("MobileData table at %d", pos)
+			for pos+4 <= len(data) {
+				idx := int32(binary.BigEndian.Uint32(data[pos : pos+4]))
+				pos += 4
+				if idx == -1 {
+					break
+				}
+				if pos+16 > len(data) {
+					pos = len(data)
+					break
+				}
+				stateVal := binary.BigEndian.Uint32(data[pos : pos+4])
+				h := int16(binary.BigEndian.Uint32(data[pos+4 : pos+8]))
+				v := int16(binary.BigEndian.Uint32(data[pos+8 : pos+12]))
+				colors := uint8(binary.BigEndian.Uint32(data[pos+12 : pos+16]))
+				pos += 16
+				if pos+168 > len(data) {
+					pos = len(data)
+					break
+				}
+				desc := data[pos : pos+168]
+				pictID := binary.BigEndian.Uint32(desc[0:4])
+				nameBytes := bytes.TrimRight(desc[98:146], "\x00")
+				name := decodeMacRoman(nameBytes)
+				colorData := append([]byte(nil), desc[68:98]...)
+				pos += 168
+				if binary.BigEndian.Uint32(desc[28:32]) != 0 {
+					if pos+2 > len(data) {
+						pos = len(data)
+						break
+					}
+					bubLen := int(binary.BigEndian.Uint16(data[pos : pos+2]))
+					pos += 2 + bubLen
+				}
+				d := frameDescriptor{Index: uint8(idx), PictID: uint16(pictID), Name: name, Colors: colorData}
+				m := frameMobile{Index: uint8(idx), State: uint8(stateVal), H: h, V: v, Colors: colors}
+				stateMu.Lock()
+				if state.descriptors == nil {
+					state.descriptors = make(map[uint8]frameDescriptor)
+				}
+				state.descriptors[uint8(idx)] = d
+				if state.mobiles == nil {
+					state.mobiles = make(map[uint8]frameMobile)
+				}
+				state.mobiles[m.Index] = m
+				stateMu.Unlock()
+			}
+			continue
+		}
+		if flags&flagPictureTable != 0 {
+			dlog("PictureTable at %d", pos)
+			if pos+2 > len(data) {
+				break
+			}
+			count := int(binary.BigEndian.Uint16(data[pos : pos+2]))
+			pos += 2
+			pics := make([]framePicture, 0, count)
+			for i := 0; i < count && pos+6 <= len(data); i++ {
+				id := binary.BigEndian.Uint16(data[pos : pos+2])
+				h := int16(binary.BigEndian.Uint16(data[pos+2 : pos+4]))
+				v := int16(binary.BigEndian.Uint16(data[pos+4 : pos+6]))
+				pos += 6
+				pics = append(pics, framePicture{PictID: id, H: h, V: v})
+			}
+			if pos+4 <= len(data) {
+				pos += 4
+			}
+			stateMu.Lock()
+			state.pictures = pics
+			stateMu.Unlock()
+			continue
+		}
 		if size > 0 {
 			if pos+size > len(data) {
 				break
@@ -55,6 +144,7 @@ func parseMovie(path string) ([][]byte, error) {
 			}
 			pos += idx
 		}
+		frameNum++
 	}
 	return frames, nil
 }

--- a/go_client/movie.go
+++ b/go_client/movie.go
@@ -75,19 +75,18 @@ func parseMovie(path string) ([][]byte, error) {
 				v := int16(binary.BigEndian.Uint32(data[pos+8 : pos+12]))
 				colors := uint8(binary.BigEndian.Uint32(data[pos+12 : pos+16]))
 				pos += 16
-				if pos+168 > len(data) {
+				if pos+156 > len(data) {
 					pos = len(data)
 					break
 				}
-				// descriptor structs in movie files include
-				// AUTO_HIDENAME fields so the minimum size is
-				// 176 bytes (offset of descBubbleText)
-				desc := data[pos : pos+176]
+				// descriptor structs in movie files place
+				// descBubbleText 156 bytes from the start.
+				desc := data[pos : pos+156]
 				pictID := binary.BigEndian.Uint32(desc[0:4])
 				nameBytes := bytes.TrimRight(desc[98:146], "\x00")
 				name := decodeMacRoman(nameBytes)
 				colorData := append([]byte(nil), desc[68:98]...)
-				pos += 176
+				pos += 156
 				if binary.BigEndian.Uint32(desc[28:32]) != 0 {
 					if pos+2 > len(data) {
 						pos = len(data)

--- a/go_client/movie.go
+++ b/go_client/movie.go
@@ -79,12 +79,15 @@ func parseMovie(path string) ([][]byte, error) {
 					pos = len(data)
 					break
 				}
-				desc := data[pos : pos+168]
+				// descriptor structs in movie files include
+				// AUTO_HIDENAME fields so the minimum size is
+				// 176 bytes (offset of descBubbleText)
+				desc := data[pos : pos+176]
 				pictID := binary.BigEndian.Uint32(desc[0:4])
 				nameBytes := bytes.TrimRight(desc[98:146], "\x00")
 				name := decodeMacRoman(nameBytes)
 				colorData := append([]byte(nil), desc[68:98]...)
-				pos += 168
+				pos += 176
 				if binary.BigEndian.Uint32(desc[28:32]) != 0 {
 					if pos+2 > len(data) {
 						pos = len(data)

--- a/scripts/build_go_client.sh
+++ b/scripts/build_go_client.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+cd "$(dirname "$0")/../go_client"
+# fetch dependencies and format the source
+go mod download
+[ -n "$(command -v gofmt)" ] && gofmt -w *.go
+# build all packages
+go build ./...

--- a/scripts/run_go_client.sh
+++ b/scripts/run_go_client.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+cd "$(dirname "$0")/../go_client"
+exec go run . "$@"


### PR DESCRIPTION
## Summary
- parse flagged GameState, MobileData, and PictureTable frames when reading clmov files
- store parsed descriptors, mobiles and cached pictures at movie load time
- log debugging information about each frame while parsing

## Testing
- `go mod download`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ce2d7d5a0832abec796e7e6b74a99