### PR TITLE
Enable mouse click input

### DIFF
--- a/go_client/game.go
+++ b/go_client/game.go
@@ -20,6 +20,7 @@ const gameAreaSizeX, gameAreaSizeY = 547, 540
 const fieldCenterX, fieldCenterY = gameAreaSizeX / 2, gameAreaSizeY / 2
 
 var mouseX, mouseY uint16
+var mouseDown bool
 
 var gameCtx context.Context
 var scale int = 3
@@ -54,6 +55,7 @@ func (g *Game) Update() error {
 	x, y := ebiten.CursorPosition()
 	mouseX = uint16(x)
 	mouseY = uint16(y)
+	mouseDown = ebiten.IsMouseButtonPressed(ebiten.MouseButtonLeft)
 	return nil
 }
 

--- a/go_client/network.go
+++ b/go_client/network.go
@@ -90,17 +90,21 @@ func readUDPMessage(conn net.Conn) ([]byte, error) {
 
 func sendPlayerInput(conn net.Conn) error {
 	const kMsgPlayerInput = 3
+	flags := uint16(0)
+	if mouseDown {
+		flags = kPIMDownField
+	}
 	buf := make([]byte, 20+1)
 	binary.BigEndian.PutUint16(buf[0:2], kMsgPlayerInput)
 	binary.BigEndian.PutUint16(buf[2:4], mouseX)
 	binary.BigEndian.PutUint16(buf[4:6], mouseY)
-	binary.BigEndian.PutUint16(buf[6:8], 0)
+	binary.BigEndian.PutUint16(buf[6:8], flags)
 	binary.BigEndian.PutUint32(buf[8:12], uint32(ackFrame))
 	binary.BigEndian.PutUint32(buf[12:16], uint32(resendFrame))
 	binary.BigEndian.PutUint32(buf[16:20], commandNum)
 	buf[20] = 0
 	commandNum++
-	dlog("player input ack=%d resend=%d cmd=%d mouse=%d,%d", ackFrame, resendFrame, commandNum-1, mouseX, mouseY)
+	dlog("player input ack=%d resend=%d cmd=%d mouse=%d,%d flags=%#x", ackFrame, resendFrame, commandNum-1, mouseX, mouseY, flags)
 	return sendUDPMessage(conn, buf)
 }
 

--- a/go_client/util.go
+++ b/go_client/util.go
@@ -112,6 +112,58 @@ const (
 	kBubbleFar       = 0x80
 )
 
+const kPIMDownField = 0x0001 // mouse down; player wants to move
+
+// illumination flags from Public_cl.h
+const (
+	kLightAdjust25Pct  = 1 << 0
+	kLightAdjust50Pct  = 1 << 1
+	kLightAreaIsDarker = 1 << 2
+	kLightNoNightMods  = 1 << 3
+	kLightNoShadows    = 1 << 4
+	kLightForce100Pct  = 1 << 5
+)
+
+// inventory command values from Public_cl.h
+const (
+	kInvCmdNone = iota
+	kInvCmdFull
+	kInvCmdAdd
+	kInvCmdAddEquip
+	kInvCmdDelete
+	kInvCmdEquip
+	kInvCmdUnequip
+	kInvCmdMultiple
+	kInvCmdName
+
+	kInvCmdIndex = 0x80
+)
+
+// item slots from Public_cl.h
+const (
+	kItemSlotNotInventory = iota
+	kItemSlotNotWearable
+	kItemSlotForehead
+	kItemSlotNeck
+	kItemSlotShoulder
+	kItemSlotArms
+	kItemSlotGloves
+	kItemSlotFinger
+	kItemSlotCoat
+	kItemSlotCloak
+	kItemSlotTorso
+	kItemSlotWaist
+	kItemSlotLegs
+	kItemSlotFeet
+	kItemSlotRightHand
+	kItemSlotLeftHand
+	kItemSlotBothHands
+	kItemSlotHead
+
+	kItemSlotFirstReal = kItemSlotForehead
+	kItemSlotLastReal  = kItemSlotHead
+)
+
 const beppChar = "\302"
 
 func readKeyFileVersion(path string) (uint32, error) {


### PR DESCRIPTION
## Summary
- track mouse button state in Ebiten update loop
- send kPIMDownField flag when mouse is down
- log mouse flags when sending player input
- add illumination, inventory, and item slot flags from Public_cl.h

## Testing
- `go mod download`
- `go build`


------
https://chatgpt.com/codex/tasks/task_e_688ce9f19d24832aa4a2e0e5456a104f