### PR TITLE
Add flag to enable movement interpolation

### DIFF
--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -202,24 +202,26 @@ func parseDrawState(data []byte) bool {
 	copy(newPics[again:], pics)
 	state.pictures = newPics
 
-	// save previous mobile positions for interpolation
-	if state.prevMobiles == nil {
-		state.prevMobiles = make(map[uint8]frameMobile)
-	}
-	// copy current mobiles to prevMobiles before replacing
-	state.prevMobiles = make(map[uint8]frameMobile, len(state.mobiles))
-	for idx, m := range state.mobiles {
-		state.prevMobiles[idx] = m
-	}
-	const defaultInterval = time.Second / 5
-	interval := defaultInterval
-	if !state.prevTime.IsZero() && !state.curTime.IsZero() {
-		if d := state.curTime.Sub(state.prevTime); d > 0 {
-			interval = d
+	if interp {
+		// save previous mobile positions for interpolation
+		if state.prevMobiles == nil {
+			state.prevMobiles = make(map[uint8]frameMobile)
 		}
+		// copy current mobiles to prevMobiles before replacing
+		state.prevMobiles = make(map[uint8]frameMobile, len(state.mobiles))
+		for idx, m := range state.mobiles {
+			state.prevMobiles[idx] = m
+		}
+		const defaultInterval = time.Second / 5
+		interval := defaultInterval
+		if !state.prevTime.IsZero() && !state.curTime.IsZero() {
+			if d := state.curTime.Sub(state.prevTime); d > 0 {
+				interval = d
+			}
+		}
+		state.prevTime = time.Now()
+		state.curTime = state.prevTime.Add(interval)
 	}
-	state.prevTime = time.Now()
-	state.curTime = state.prevTime.Add(interval)
 
 	if state.mobiles == nil {
 		state.mobiles = make(map[uint8]frameMobile)

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -24,6 +24,7 @@ var mouseDown bool
 
 var gameCtx context.Context
 var scale int = 3
+var interp bool
 
 // drawState tracks information needed by the Ebiten renderer.
 type drawState struct {
@@ -74,16 +75,19 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	for _, m := range state.mobiles {
 		mobiles = append(mobiles, m)
 	}
-	prevMobiles := make(map[uint8]frameMobile, len(state.prevMobiles))
-	for idx, m := range state.prevMobiles {
-		prevMobiles[idx] = m
+	var prevMobiles map[uint8]frameMobile
+	if interp {
+		prevMobiles = make(map[uint8]frameMobile, len(state.prevMobiles))
+		for idx, m := range state.prevMobiles {
+			prevMobiles[idx] = m
+		}
 	}
 	prevTime := state.prevTime
 	curTime := state.curTime
 	stateMu.Unlock()
 
 	alpha := 1.0
-	if !curTime.IsZero() && curTime.After(prevTime) {
+	if interp && !curTime.IsZero() && curTime.After(prevTime) {
 		elapsed := time.Since(prevTime)
 		interval := curTime.Sub(prevTime)
 		alpha = float64(elapsed) / float64(interval)
@@ -126,9 +130,11 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	drawMobile := func(m frameMobile) {
 		h := float64(m.H)
 		v := float64(m.V)
-		if pm, ok := prevMobiles[m.Index]; ok {
-			h = float64(pm.H)*(1-alpha) + float64(m.H)*alpha
-			v = float64(pm.V)*(1-alpha) + float64(m.V)*alpha
+		if interp {
+			if pm, ok := prevMobiles[m.Index]; ok {
+				h = float64(pm.H)*(1-alpha) + float64(m.H)*alpha
+				v = float64(pm.V)*(1-alpha) + float64(m.V)*alpha
+			}
 		}
 		x := int(math.Round(h)) + fieldCenterX
 		y := int(math.Round(v)) + fieldCenterY

--- a/go_client/main.go
+++ b/go_client/main.go
@@ -26,6 +26,7 @@ func main() {
 	clientVer := flag.Int("client-version", 1440, "client version number (kVersionNumber)")
 	flag.BoolVar(&debug, "debug", true, "enable debug logging")
 	flag.IntVar(&scale, "scale", 2, "screen scale factor")
+	flag.BoolVar(&interp, "interp", false, "enable movement interpolation")
 	flag.Parse()
 
 	var imgErr error


### PR DESCRIPTION
## Summary
- add `interp` command line flag
- disable interpolation by default in draw state processing and rendering
- conditionally smooth movement when `-interp` is specified

## Testing
- `go mod download`
- `go build`

------
https://chatgpt.com/codex/tasks/task_e_688cf03e0434832a8d0ec731b5d39717