### PR TITLE
Fix onion cross-fade transparency

### DIFF
--- a/go_client/game.go
+++ b/go_client/game.go
@@ -185,15 +185,22 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		if img != nil {
 			size := img.Bounds().Dx()
 			if onion && prevImg != nil {
+				tmp := ebiten.NewImage(size, size)
+				tmp.Clear()
+
 				op1 := &ebiten.DrawImageOptions{}
-				op1.GeoM.Translate(float64(x-size/2), float64(y-size/2))
 				op1.ColorScale.ScaleAlpha(1 - fade)
-				screen.DrawImage(prevImg, op1)
+				op1.Blend = ebiten.BlendCopy
+				tmp.DrawImage(prevImg, op1)
 
 				op2 := &ebiten.DrawImageOptions{}
-				op2.GeoM.Translate(float64(x-size/2), float64(y-size/2))
 				op2.ColorScale.ScaleAlpha(fade)
-				screen.DrawImage(img, op2)
+				op2.Blend = ebiten.BlendLighter
+				tmp.DrawImage(img, op2)
+
+				op := &ebiten.DrawImageOptions{}
+				op.GeoM.Translate(float64(x-size/2), float64(y-size/2))
+				screen.DrawImage(tmp, op)
 			} else {
 				op := &ebiten.DrawImageOptions{}
 				op.GeoM.Translate(float64(x-size/2), float64(y-size/2))


### PR DESCRIPTION
## Summary
- when cross-fading sprites, blend the two frames onto a temporary image to keep full opacity

## Testing
- `go build ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688d4be7e36c832a9b62206717770984