### PR TITLE
Fix click-to-walk latency

### DIFF
--- a/go_client/game.go
+++ b/go_client/game.go
@@ -340,7 +340,11 @@ func runGame(ctx context.Context) {
 }
 
 func sendInputLoop(ctx context.Context, conn net.Conn) {
-	ticker := time.NewTicker(2 * time.Second)
+	// The original C client sends input roughly once per frame
+	// (~20 times per second). Using a long interval here results in
+	// very sluggish or broken click-to-move behaviour, so shorten
+	// the ticker to match the classic client.
+	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	for {
 		if err := sendPlayerInput(conn); err != nil {


### PR DESCRIPTION
## Summary
- align input send interval with C client

## Testing
- `go build ./...`
- `go test ./... -run TestParseMovie -v`

------
https://chatgpt.com/codex/tasks/task_e_688d61fe4a0c832aaaf32616647e56e2