### PR TITLE
Update README with build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,53 @@
 This repository contains source for the open source Clan Lord clients.  A minimal
 Go program under `go_client/` demonstrates how to connect to the game servers.
 
+## Building the Go client
+
+The Go client requires **Go 1.24 or later** and development packages for
+OpenGL/X11. On Debian/Ubuntu systems these can be installed with:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y golang-go build-essential libgl1-mesa-dev libglu1-mesa-dev xorg-dev
+```
+
+To compile the program run the helper script from the repository root:
+
+```bash
+scripts/build_go_client.sh
+```
+
+This fetches module dependencies, formats the sources and builds all packages
+inside `go_client/`.  Alternatively you can build manually:
+
+```bash
+cd go_client
+go build
+```
+
+The client can then be launched with:
+
+```bash
+go run .
+```
+
+or simply use `scripts/run_go_client.sh` from the repository root.
+
+### Command-line flags
+
+The Go client accepts the following flags:
+
+- `-host` – server address (default `server.deltatao.com:5010`)
+- `-clmov` – play back a `.clMov` movie file instead of connecting to a server
+- `-name` – character name (default `demo`)
+- `-pass` – character password (default `demo`)
+- `-client-version` – client version number (`kVersionNumber`, default `1440`)
+- `-debug` – enable debug logging (default `true`)
+- `-scale` – screen scale factor (default `2`)
+- `-interp` – enable movement interpolation
+- `-onion` – cross-fade sprite animations
+- `-linear` – use linear filtering instead of nearest-neighbor rendering
+
 ## Demo characters
 
 The game offers a set of free demo characters accessible using the special


### PR DESCRIPTION
## Summary
- add a new section documenting Go client command-line flags

## Testing
- `go build ./...`
- `go test ./... -run TestParseMovie -v`
- `go run .` *(fails: X11 DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d61421b34832aa583153fca3732da