### PR TITLE
Center-based mouse coordinates

### DIFF
--- a/go_client/game.go
+++ b/go_client/game.go
@@ -20,7 +20,7 @@ const gameAreaSizeX, gameAreaSizeY = 547, 540
 const fieldCenterX, fieldCenterY = gameAreaSizeX / 2, gameAreaSizeY / 2
 const epsilon = 0.01 // in pixels
 
-var mouseX, mouseY uint16
+var mouseX, mouseY int16
 var mouseDown bool
 
 var gameCtx context.Context

--- a/go_client/network.go
+++ b/go_client/network.go
@@ -95,8 +95,8 @@ func sendPlayerInput(conn net.Conn) error {
 	flags := uint16(0)
 
 	x, y := ebiten.CursorPosition()
-	mouseX = uint16(x / scale)
-	mouseY = uint16(y / scale)
+	mouseX = int16(x/scale - fieldCenterX)
+	mouseY = int16(y/scale - fieldCenterY)
 	mouseDown = ebiten.IsMouseButtonPressed(ebiten.MouseButtonLeft)
 
 	if mouseDown {
@@ -104,8 +104,8 @@ func sendPlayerInput(conn net.Conn) error {
 	}
 	buf := make([]byte, 20+1)
 	binary.BigEndian.PutUint16(buf[0:2], kMsgPlayerInput)
-	binary.BigEndian.PutUint16(buf[2:4], mouseX)
-	binary.BigEndian.PutUint16(buf[4:6], mouseY)
+	binary.BigEndian.PutUint16(buf[2:4], uint16(mouseX))
+	binary.BigEndian.PutUint16(buf[4:6], uint16(mouseY))
 	binary.BigEndian.PutUint16(buf[6:8], flags)
 	binary.BigEndian.PutUint32(buf[8:12], uint32(ackFrame))
 	binary.BigEndian.PutUint32(buf[12:16], uint32(resendFrame))


### PR DESCRIPTION
## Summary
- compute mouse coordinates relative to the window center
- store mouse coordinates as signed offsets before network transmission

## Testing
- `go mod download`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d65628ca4832aa3933eb6530d6b41