### PR TITLE
Add health, mana, and move bars to Go client

### DIFF
--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -216,7 +216,14 @@ func parseDrawState(data []byte) bool {
 	if len(data) < p+7 {
 		return false
 	}
-	p += 7 // skip status fields
+	hp := int(data[p])
+	hpMax := int(data[p+1])
+	sp := int(data[p+2])
+	spMax := int(data[p+3])
+	bal := int(data[p+4])
+	balMax := int(data[p+5])
+	// lighting := data[p+6]
+	p += 7
 
 	if len(data) <= p {
 		return false
@@ -266,6 +273,12 @@ func parseDrawState(data []byte) bool {
 	stateData := data[p:]
 
 	stateMu.Lock()
+	state.hp = hp
+	state.hpMax = hpMax
+	state.sp = sp
+	state.spMax = spMax
+	state.balance = bal
+	state.balanceMax = balMax
 	changed := false
 	if onion {
 		if len(descs) > 0 {

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -362,21 +362,28 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	ebitenutil.DebugPrintAt(screen, fmt.Sprintf("desc:%d pict:%d mobile:%d", len(descs), len(pics), len(mobiles)), 490*scale, 460*scale)
 
 	// draw status bars
-	barWidth := (gameAreaSizeX*scale - 4*scale*4) / 3
+	gap := 4 * scale
+	barWidth := ((gameAreaSizeX*scale - gap*2) / 3) / 2
 	barHeight := 8 * scale
-	barY := 480*scale + 4*scale
-	x := 4 * scale
+	barY := gameAreaSizeY*scale - barHeight - 2
+	totalWidth := 3*barWidth + gap*2
+	x := (gameAreaSizeX*scale - totalWidth) / 2
+	barAlpha := uint8(0xb3)
 	drawBar := func(x int, cur, max int, clr color.RGBA) {
-		ebitenutil.DrawRect(screen, float64(x), float64(barY), float64(barWidth), float64(barHeight), color.RGBA{0x40, 0x40, 0x40, 0xff})
+		frameClr := color.RGBA{0xff, 0xff, 0xff, barAlpha}
+		bgClr := color.RGBA{0x40, 0x40, 0x40, barAlpha}
+		ebitenutil.DrawRect(screen, float64(x-scale), float64(barY-scale), float64(barWidth+2*scale), float64(barHeight+2*scale), frameClr)
+		ebitenutil.DrawRect(screen, float64(x), float64(barY), float64(barWidth), float64(barHeight), bgClr)
 		if max > 0 && cur > 0 {
 			w := barWidth * cur / max
-			ebitenutil.DrawRect(screen, float64(x), float64(barY), float64(w), float64(barHeight), clr)
+			fillClr := color.RGBA{clr.R, clr.G, clr.B, barAlpha}
+			ebitenutil.DrawRect(screen, float64(x), float64(barY), float64(w), float64(barHeight), fillClr)
 		}
 	}
 	drawBar(x, hp, hpMax, color.RGBA{0xff, 0, 0, 0xff})
-	x += barWidth + 4*scale
+	x += barWidth + gap
 	drawBar(x, balance, balanceMax, color.RGBA{0x00, 0xff, 0x00, 0xff})
-	x += barWidth + 4*scale
+	x += barWidth + gap
 	drawBar(x, sp, spMax, color.RGBA{0x00, 0x00, 0xff, 0xff})
 
 	msgs := getMessages()

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -47,6 +47,10 @@ type drawState struct {
 	prevDescs   map[uint8]frameDescriptor
 	prevTime    time.Time
 	curTime     time.Time
+
+	hp, hpMax           int
+	sp, spMax           int
+	balance, balanceMax int
 }
 
 var (
@@ -128,6 +132,12 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	}
 	prevTime := state.prevTime
 	curTime := state.curTime
+	hp := state.hp
+	hpMax := state.hpMax
+	sp := state.sp
+	spMax := state.spMax
+	balance := state.balance
+	balanceMax := state.balanceMax
 	stateMu.Unlock()
 
 	alpha := 1.0
@@ -350,6 +360,24 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	}
 	//ebitenutil.DebugPrintAt(screen, strings.Join(lines, "\n"), 4*scale, 4*scale)
 	ebitenutil.DebugPrintAt(screen, fmt.Sprintf("desc:%d pict:%d mobile:%d", len(descs), len(pics), len(mobiles)), 490*scale, 460*scale)
+
+	// draw status bars
+	barWidth := (gameAreaSizeX*scale - 4*scale*4) / 3
+	barHeight := 8 * scale
+	barY := 480*scale + 4*scale
+	x := 4 * scale
+	drawBar := func(x int, cur, max int, clr color.RGBA) {
+		ebitenutil.DrawRect(screen, float64(x), float64(barY), float64(barWidth), float64(barHeight), color.RGBA{0x40, 0x40, 0x40, 0xff})
+		if max > 0 && cur > 0 {
+			w := barWidth * cur / max
+			ebitenutil.DrawRect(screen, float64(x), float64(barY), float64(w), float64(barHeight), clr)
+		}
+	}
+	drawBar(x, hp, hpMax, color.RGBA{0xff, 0, 0, 0xff})
+	x += barWidth + 4*scale
+	drawBar(x, balance, balanceMax, color.RGBA{0x00, 0xff, 0x00, 0xff})
+	x += barWidth + 4*scale
+	drawBar(x, sp, spMax, color.RGBA{0x00, 0x00, 0xff, 0xff})
 
 	msgs := getMessages()
 	startY := 480*scale - 12*len(msgs)*scale - 6*scale

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
+	"github.com/hajimehoshi/ebiten/v2/vector"
 )
 
 const gameAreaSizeX, gameAreaSizeY = 547, 540
@@ -256,7 +257,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				screen.DrawImage(img, op)
 			}
 		} else {
-			ebitenutil.DrawRect(screen, float64(x)-3*float64(scale), float64(y)-3*float64(scale), 6*float64(scale), 6*float64(scale), color.RGBA{0xff, 0, 0, 0xff})
+			vector.DrawFilledRect(screen, float32(x-3*scale), float32(y-3*scale), float32(6*scale), float32(6*scale), color.RGBA{0xff, 0, 0, 0xff}, false)
 		}
 		texts = append(texts, textItem{x + 6*scale, y - 8*scale, fmt.Sprintf("%d", m.Index)})
 	}
@@ -282,7 +283,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			op.GeoM.Translate(float64(x-w*scale/2), float64(y-h*scale/2))
 			screen.DrawImage(img, op)
 		} else {
-			ebitenutil.DrawRect(screen, float64(x)-2*float64(scale), float64(y)-2*float64(scale), 4*float64(scale), 4*float64(scale), color.RGBA{0, 0, 0xff, 0xff})
+			vector.DrawFilledRect(screen, float32(x-2*scale), float32(y-2*scale), float32(4*scale), float32(4*scale), color.RGBA{0, 0, 0xff, 0xff}, false)
 		}
 		texts = append(texts, textItem{x + 4*scale, y - 8*scale, fmt.Sprintf("%d", p.PictID)})
 	}
@@ -372,12 +373,12 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	drawBar := func(x int, cur, max int, clr color.RGBA) {
 		frameClr := color.RGBA{0xff, 0xff, 0xff, barAlpha}
 		bgClr := color.RGBA{0x40, 0x40, 0x40, barAlpha}
-		ebitenutil.DrawRect(screen, float64(x-scale), float64(barY-scale), float64(barWidth+2*scale), float64(barHeight+2*scale), frameClr)
-		ebitenutil.DrawRect(screen, float64(x), float64(barY), float64(barWidth), float64(barHeight), bgClr)
+		vector.DrawFilledRect(screen, float32(x-scale), float32(barY-scale), float32(barWidth+2*scale), float32(barHeight+2*scale), frameClr, false)
+		vector.DrawFilledRect(screen, float32(x), float32(barY), float32(barWidth), float32(barHeight), bgClr, false)
 		if max > 0 && cur > 0 {
 			w := barWidth * cur / max
 			fillClr := color.RGBA{clr.R, clr.G, clr.B, barAlpha}
-			ebitenutil.DrawRect(screen, float64(x), float64(barY), float64(w), float64(barHeight), fillClr)
+			vector.DrawFilledRect(screen, float32(x), float32(barY), float32(w), float32(barHeight), fillClr, false)
 		}
 	}
 	drawBar(x, hp, hpMax, color.RGBA{0xff, 0, 0, 0xff})

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -411,6 +411,7 @@ func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
 func runGame(ctx context.Context) {
 	gameCtx = ctx
 	ebiten.SetWindowSize(gameAreaSizeX*scale, gameAreaSizeY*scale)
+	ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 	ebiten.SetWindowTitle("Draw State")
 	if err := ebiten.RunGame(&Game{}); err != nil {
 		log.Printf("ebiten: %v", err)


### PR DESCRIPTION
## Summary
- Parse HP, mana, and balance fields from draw state and store in render state
- Render bottom HUD bars for health, movement, and mana values

## Testing
- `go test ./...`
- `go build`


------
https://chatgpt.com/codex/tasks/task_e_688d8057575c832a82874edeb12bdd2d