### PR TITLE
Strip BEPP tags from chat decoding

### DIFF
--- a/go_client/decode.go
+++ b/go_client/decode.go
@@ -41,6 +41,27 @@ func decodeBEPP(data []byte) string {
 	}
 }
 
+func stripBEPPTags(b []byte) []byte {
+	out := b[:0]
+	for i := 0; i < len(b); {
+		c := b[i]
+		if c == 0xC2 {
+			if i+2 < len(b) {
+				i += 3
+				continue
+			}
+			break
+		}
+		if c >= 0x80 || c < 0x20 {
+			i++
+			continue
+		}
+		out = append(out, c)
+		i++
+	}
+	return out
+}
+
 func decodeBubble(data []byte) string {
 	if len(data) < 2 {
 		return ""
@@ -62,7 +83,7 @@ func decodeBubble(data []byte) string {
 	if len(data) <= p {
 		return ""
 	}
-	msgData := data[p:]
+	msgData := stripBEPPTags(data[p:])
 	if i := bytes.IndexByte(msgData, 0); i >= 0 {
 		msgData = msgData[:i]
 	}
@@ -151,7 +172,7 @@ func handleInfoText(data []byte) {
 			addMessage(txt)
 			continue
 		}
-		s := strings.TrimSpace(decodeMacRoman(line))
+		s := strings.TrimSpace(decodeMacRoman(stripBEPPTags(line)))
 		if s == "" || strings.HasPrefix(s, "/") {
 			continue
 		}

--- a/go_client/decode_test.go
+++ b/go_client/decode_test.go
@@ -1,0 +1,18 @@
+package main
+
+import "testing"
+
+func TestDecodeBubbleStripsTags(t *testing.T) {
+	data := []byte{0x00, byte(kBubbleWhisper), 0x8A, 0xC2, 'p', 'n', ' ', 'p', 'i', 'n', 'g', '!', 0}
+	got := decodeBubble(data)
+	if got != "whisper: ping!" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestDecodeBubbleEmptyAfterStripping(t *testing.T) {
+	data := []byte{0x00, byte(kBubbleNormal), 0x8A, 0xC2, 'p', 'n', 0}
+	if got := decodeBubble(data); got != "" {
+		t.Fatalf("got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- remove BEPP tag sequences and high-bit control bytes from incoming text
- ensure info text and bubbles decode cleanly without empty "say:" lines
- add tests for chat decoding

## Testing
- `go build ./...`
- `go test ./...` *(fails: "glfw: X11: The DISPLAY environment variable is missing")*

------
https://chatgpt.com/codex/tasks/task_e_688d8368ce40832a92080669caf30814