### PR TITLE
Parse BEP tags for player tracking

### DIFF
--- a/go_client/bep.go
+++ b/go_client/bep.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+)
+
+// parseBackend handles back-end BEP commands following the "be" prefix.
+func parseBackend(data []byte) {
+	if len(data) < 3 || data[0] != 0xC2 {
+		return
+	}
+	cmd := string(data[1:3])
+	payload := data[3:]
+	switch cmd {
+	case "in":
+		parseBackendInfo(payload)
+	case "sh":
+		parseBackendShare(payload)
+	case "wh":
+		parseBackendWho(payload)
+	}
+}
+
+// parseBackendInfo parses "be-in" messages containing player info.
+func parseBackendInfo(data []byte) {
+	if len(data) < 3 || data[0] != 0xC2 || data[1] != 'p' || data[2] != 'n' {
+		return
+	}
+	rest := data[3:]
+	end := bytes.Index(rest, []byte{0xC2, 'p', 'n'})
+	if end < 0 {
+		return
+	}
+	name := strings.TrimSpace(decodeMacRoman(rest[:end]))
+	rest = rest[end+3:]
+	fields := bytes.Split(rest, []byte{'\t'})
+	if len(fields) < 3 {
+		return
+	}
+	race := strings.TrimSpace(decodeMacRoman(fields[0]))
+	gender := strings.TrimSpace(decodeMacRoman(fields[1]))
+	class := strings.TrimSpace(decodeMacRoman(fields[2]))
+	clan := ""
+	if len(fields) > 3 {
+		clan = strings.TrimSpace(decodeMacRoman(fields[3]))
+	}
+	p := getPlayer(name)
+	p.Race = race
+	p.Gender = gender
+	p.Class = class
+	p.Clan = clan
+}
+
+// parseBackendShare parses "be-sh" messages describing sharing relationships.
+func parseBackendShare(data []byte) {
+	for _, p := range players {
+		p.Sharee = false
+		p.Sharing = false
+	}
+	parts := bytes.SplitN(data, []byte{'\t'}, 2)
+	shareePart := parts[0]
+	var sharerPart []byte
+	if len(parts) > 1 {
+		sharerPart = parts[1]
+	}
+	for _, name := range parseNames(shareePart) {
+		getPlayer(name).Sharee = true
+	}
+	for _, name := range parseNames(sharerPart) {
+		getPlayer(name).Sharing = true
+	}
+}
+
+// parseBackendWho parses "be-wh" messages listing players.
+func parseBackendWho(data []byte) {
+	for len(data) > 0 {
+		if len(data) < 3 || data[0] != 0xC2 || data[1] != 'p' || data[2] != 'n' {
+			return
+		}
+		data = data[3:]
+		end := bytes.Index(data, []byte{0xC2, 'p', 'n'})
+		if end < 0 {
+			return
+		}
+		name := strings.TrimSpace(decodeMacRoman(data[:end]))
+		getPlayer(name)
+		data = data[end+3:]
+		idx := bytes.IndexByte(data, '\t')
+		if idx < 0 {
+			return
+		}
+		data = data[idx+1:]
+	}
+}
+
+// parseNames extracts a slice of names from a sequence of "-pn name -pn" entries.
+func parseNames(data []byte) []string {
+	var names []string
+	for len(data) >= 3 {
+		if data[0] != 0xC2 || data[1] != 'p' || data[2] != 'n' {
+			break
+		}
+		data = data[3:]
+		end := bytes.Index(data, []byte{0xC2, 'p', 'n'})
+		if end < 0 {
+			break
+		}
+		name := strings.TrimSpace(decodeMacRoman(data[:end]))
+		names = append(names, name)
+		data = data[end+3:]
+		if len(data) > 0 && data[0] == ',' {
+			data = data[1:]
+		}
+	}
+	return names
+}

--- a/go_client/decode.go
+++ b/go_client/decode.go
@@ -25,20 +25,26 @@ func decodeBEPP(data []byte) string {
 	if i := bytes.IndexByte(textBytes, 0); i >= 0 {
 		textBytes = textBytes[:i]
 	}
-	text := strings.TrimSpace(decodeMacRoman(textBytes))
-	if text == "" {
-		return ""
-	}
 	switch prefix {
 	case "th":
-		return "think: " + text
+		text := strings.TrimSpace(decodeMacRoman(textBytes))
+		if text != "" {
+			return "think: " + text
+		}
 	case "in":
-		return "info: " + text
+		text := strings.TrimSpace(decodeMacRoman(textBytes))
+		if text != "" {
+			return "info: " + text
+		}
 	case "sh":
-		return "share: " + text
-	default:
-		return ""
+		text := strings.TrimSpace(decodeMacRoman(textBytes))
+		if text != "" {
+			return "share: " + text
+		}
+	case "be":
+		parseBackend(textBytes)
 	}
+	return ""
 }
 
 func stripBEPPTags(b []byte) []byte {

--- a/go_client/decode_test.go
+++ b/go_client/decode_test.go
@@ -16,3 +16,22 @@ func TestDecodeBubbleEmptyAfterStripping(t *testing.T) {
 		t.Fatalf("got %q", got)
 	}
 }
+
+func TestParseBackendInfo(t *testing.T) {
+	players = make(map[string]*Player)
+	data := []byte("\xc2be\xc2in\xc2pnAlice\xc2pn\tHuman\tFemale\tFighter\t")
+	decodeBEPP(data)
+	p := players["Alice"]
+	if p == nil || p.Class != "Fighter" || p.Race != "Human" {
+		t.Fatalf("unexpected player: %#v", p)
+	}
+}
+
+func TestParseBackendShare(t *testing.T) {
+	players = make(map[string]*Player)
+	data := []byte("\xc2be\xc2sh\xc2pnAlice\xc2pn,\xc2pnBob\xc2pn\t\xc2pnCarol\xc2pn")
+	decodeBEPP(data)
+	if !players["Alice"].Sharee || !players["Bob"].Sharee || !players["Carol"].Sharing {
+		t.Fatalf("share parsing failed: %#v", players)
+	}
+}

--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -210,6 +210,7 @@ func parseDrawState(data []byte) bool {
 		}
 		d.Colors = append([]byte(nil), data[p:p+cnt]...)
 		p += cnt
+		updatePlayerAppearance(d.Name, d.PictID, d.Colors)
 		descs = append(descs, d)
 	}
 

--- a/go_client/player.go
+++ b/go_client/player.go
@@ -1,0 +1,31 @@
+package main
+
+// Player holds minimal information extracted from BEP messages and descriptors.
+type Player struct {
+	Name    string
+	Race    string
+	Gender  string
+	Class   string
+	Clan    string
+	PictID  uint16
+	Colors  []byte
+	Sharee  bool // player is sharing to us
+	Sharing bool // we are sharing to player
+}
+
+var players = make(map[string]*Player)
+
+func getPlayer(name string) *Player {
+	if p, ok := players[name]; ok {
+		return p
+	}
+	p := &Player{Name: name}
+	players[name] = p
+	return p
+}
+
+func updatePlayerAppearance(name string, pictID uint16, colors []byte) {
+	p := getPlayer(name)
+	p.PictID = pictID
+	p.Colors = append(p.Colors[:0], colors...)
+}


### PR DESCRIPTION
## Summary
- track player descriptors, appearance, and sharing info
- parse BEP back-end messages for player race/class/clan and sharing lists
- tests for backend info and share parsing

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d87b53a48832a88f053f3372cba8b