### PR TITLE
Parse descriptor names in draw state

### DIFF
--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -183,33 +183,29 @@ func parseDrawState(data []byte) bool {
 	p++
 	descs := make([]frameDescriptor, 0, descCount)
 	for i := 0; i < descCount && p < len(data); i++ {
-		if p+4 > len(data) {
+		if p+6 > len(data) {
 			return false
 		}
 		d := frameDescriptor{}
 		d.Index = data[p]
 		d.Type = data[p+1]
 		d.PictID = binary.BigEndian.Uint16(data[p+2:])
-		p += 4
-		if idx := bytes.IndexByte(data[p:], 0); idx >= 0 {
-			d.Name = string(data[p : p+idx])
-			p += idx + 1
-			if d.Name == playerName {
-				playerIndex = d.Index
-			}
-		} else {
+		nameLen := int(data[p+4])
+		colorLen := int(data[p+5])
+		p += 6
+		if p+nameLen > len(data) {
 			return false
 		}
-		if p >= len(data) {
+		d.Name = string(data[p : p+nameLen])
+		p += nameLen
+		if d.Name == playerName {
+			playerIndex = d.Index
+		}
+		if p+colorLen > len(data) {
 			return false
 		}
-		cnt := int(data[p])
-		p++
-		if p+cnt > len(data) {
-			return false
-		}
-		d.Colors = append([]byte(nil), data[p:p+cnt]...)
-		p += cnt
+		d.Colors = append([]byte(nil), data[p:p+colorLen]...)
+		p += colorLen
 		updatePlayerAppearance(d.Name, d.PictID, d.Colors)
 		descs = append(descs, d)
 	}

--- a/go_client/draw_test.go
+++ b/go_client/draw_test.go
@@ -1,0 +1,41 @@
+package main
+
+import "testing"
+
+func TestParseDrawStateDescriptorName(t *testing.T) {
+	// reset global state
+	state.descriptors = make(map[uint8]frameDescriptor)
+	players = make(map[string]*Player)
+
+	data := []byte{
+		0,          // ackCmd
+		0, 0, 0, 0, // ackFrame
+		0, 0, 0, 0, // resendFrame
+		1,          // descriptor count
+		1,          // index
+		2,          // type
+		0x12, 0x34, // pictID
+		3,             // name length
+		2,             // color count
+		'B', 'o', 'b', // name
+		1, 2, // colors
+		10, 20, 5, 10, 7, 8, 0, // hp/hpMax/sp/spMax/balance/balanceMax/lighting
+		0, // picture count
+		0, // mobile count
+	}
+
+	if !parseDrawState(data) {
+		t.Fatalf("parseDrawState returned false")
+	}
+	d, ok := state.descriptors[1]
+	if !ok {
+		t.Fatalf("descriptor not found")
+	}
+	if d.Name != "Bob" {
+		t.Fatalf("got name %q", d.Name)
+	}
+	p := players["Bob"]
+	if p == nil || p.PictID != 0x1234 {
+		t.Fatalf("player not updated: %#v", p)
+	}
+}


### PR DESCRIPTION
## Summary
- Parse length-prefixed names and color counts from draw state descriptors
- Add test covering descriptor name extraction

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d901e93dc832a902bd1829502ca8f