### PR TITLE
Enable command sending from input bar

### DIFF
--- a/go_client/game.go
+++ b/go_client/game.go
@@ -529,5 +529,10 @@ loop:
 }
 
 func sendChat(txt string) {
+	if tcpConn != nil {
+		if err := sendCommandText(tcpConn, txt); err != nil {
+			fmt.Printf("send chat: %v\n", err)
+		}
+	}
 	addMessage(txt)
 }

--- a/go_client/main.go
+++ b/go_client/main.go
@@ -133,7 +133,7 @@ func main() {
 			sendVersion = baseVersion - 1
 		}
 
-		tcpConn, err := net.Dial("tcp", *host)
+		tcpConn, err = net.Dial("tcp", *host)
 		if err != nil {
 			log.Fatalf("tcp connect: %v", err)
 		}

--- a/go_client/network.go
+++ b/go_client/network.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
+var tcpConn net.Conn
+
 func sendIdentifiers(conn net.Conn, clientVersion, imagesVersion, soundsVersion uint32) error {
 	const kMsgIdentifiers = 19
 	uname := os.Getenv("USER")
@@ -191,4 +193,16 @@ func requestCharList(conn net.Conn, account, password string, challenge []byte, 
 	}
 	dlog("server returned %d characters", len(names))
 	return names, nil
+}
+
+func sendCommandText(conn net.Conn, txt string) error {
+	const kMsgCommandText = 6
+	data := append([]byte(txt), 0)
+	buf := make([]byte, 16+len(data))
+	binary.BigEndian.PutUint16(buf[0:2], kMsgCommandText)
+	binary.BigEndian.PutUint16(buf[2:4], 0)
+	copy(buf[16:], data)
+	simpleEncrypt(buf[16:])
+	fmt.Printf("send command: %s\n", txt)
+	return sendMessage(conn, buf)
 }


### PR DESCRIPTION
## Summary
- allow connecting code to reuse TCP connection globally
- add `sendCommandText` helper and wire input bar to send text commands

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d984dea6c832a8929efb74bf7463b