### PR TITLE
Parse night directives and clean chat messages

### DIFF
--- a/go_client/decode.go
+++ b/go_client/decode.go
@@ -93,7 +93,25 @@ func decodeBubble(data []byte) string {
 	if i := bytes.IndexByte(msgData, 0); i >= 0 {
 		msgData = msgData[:i]
 	}
-	text := strings.TrimSpace(decodeMacRoman(msgData))
+	lines := bytes.Split(msgData, []byte{'\r'})
+	var text string
+	for _, ln := range lines {
+		if len(ln) == 0 {
+			continue
+		}
+		s := strings.TrimSpace(decodeMacRoman(ln))
+		if s == "" {
+			continue
+		}
+		if parseNightCommand(s) {
+			continue
+		}
+		if text == "" {
+			text = s
+		} else {
+			text += " " + s
+		}
+	}
 	if text == "" {
 		return ""
 	}
@@ -179,7 +197,13 @@ func handleInfoText(data []byte) {
 			continue
 		}
 		s := strings.TrimSpace(decodeMacRoman(stripBEPPTags(line)))
-		if s == "" || strings.HasPrefix(s, "/") {
+		if s == "" {
+			continue
+		}
+		if parseNightCommand(s) {
+			continue
+		}
+		if strings.HasPrefix(s, "/") {
 			continue
 		}
 		fmt.Println(s)

--- a/go_client/night.go
+++ b/go_client/night.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"regexp"
+	"strconv"
+	"sync"
+)
+
+type NightInfo struct {
+	mu       sync.Mutex
+	Level    int
+	SunAngle int
+	Cloudy   bool
+}
+
+var gNight NightInfo
+
+var nightRE = regexp.MustCompile(`^/nt ([0-9]+) /sa ([-0-9]+) /cl ([01])`)
+
+func parseNightCommand(s string) bool {
+	m := nightRE.FindStringSubmatch(s)
+	if m == nil {
+		return false
+	}
+	lvl, _ := strconv.Atoi(m[1])
+	sa, _ := strconv.Atoi(m[2])
+	cloudy := m[3] != "0"
+	gNight.mu.Lock()
+	gNight.Level = lvl
+	gNight.SunAngle = sa
+	gNight.Cloudy = cloudy
+	gNight.mu.Unlock()
+	return true
+}


### PR DESCRIPTION
## Summary
- parse `/nt /sa /cl` night settings into new NightInfo structure
- strip night directives from bubble and info text messages

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d98adb2e0832ab30a12d01d1f7773