### PR TITLE
Register player names when parsing movie descriptors

### DIFF
--- a/go_client/movie.go
+++ b/go_client/movie.go
@@ -167,6 +167,9 @@ func parseMobileTable(data []byte, pos int) int {
 		} else {
 			d.Name = string(nameBytes)
 		}
+		if d.Name != "" {
+			updatePlayerAppearance(d.Name, d.PictID, d.Colors)
+		}
 		bubbleCounter := int32(binary.BigEndian.Uint32(buf[28:32]))
 		if bubbleCounter != 0 {
 			if pos+2 > len(data) {

--- a/go_client/movie_test.go
+++ b/go_client/movie_test.go
@@ -1,0 +1,15 @@
+package main
+
+import "testing"
+
+func TestParseMovieRegistersPlayers(t *testing.T) {
+	players = make(map[string]*Player)
+	state.descriptors = make(map[uint8]frameDescriptor)
+	state.mobiles = make(map[uint8]frameMobile)
+	if _, err := parseMovie("test.clMov"); err != nil {
+		t.Fatalf("parseMovie: %v", err)
+	}
+	if len(players) == 0 {
+		t.Fatalf("players not registered")
+	}
+}


### PR DESCRIPTION
## Summary
- register players encountered in a movie's descriptor table
- add test ensuring movie parsing populates the player list

## Testing
- `go test -run TestParseMovieRegistersPlayers -v` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_688d9b611cd8832aa0d7f369e245c7e8