### PR TITLE
Handle player name tags in messages

### DIFF
--- a/go_client/decode.go
+++ b/go_client/decode.go
@@ -16,56 +16,92 @@ func decodeMacRoman(b []byte) string {
 	return string(str)
 }
 
-func decodeBEPP(data []byte) string {
-	if len(data) < 3 || data[0] != 0xC2 {
-		return ""
-	}
-	prefix := string(data[1:3])
-	textBytes := data[3:]
-	if i := bytes.IndexByte(textBytes, 0); i >= 0 {
-		textBytes = textBytes[:i]
-	}
-	switch prefix {
-	case "th":
-		text := strings.TrimSpace(decodeMacRoman(textBytes))
-		if text != "" {
-			return "think: " + text
-		}
-	case "in":
-		text := strings.TrimSpace(decodeMacRoman(textBytes))
-		if text != "" {
-			return "info: " + text
-		}
-	case "sh":
-		text := strings.TrimSpace(decodeMacRoman(textBytes))
-		if text != "" {
-			return "share: " + text
-		}
-	case "be":
-		parseBackend(textBytes)
-	}
-	return ""
+func decodeBEPP(data []byte) (string, MsgClass) {
+        if len(data) < 3 || data[0] != 0xC2 {
+                return "", MsgDefault
+        }
+        prefix := string(data[1:3])
+        textBytes := data[3:]
+        if i := bytes.IndexByte(textBytes, 0); i >= 0 {
+                textBytes = textBytes[:i]
+        }
+        if prefix == "be" {
+                parseBackend(textBytes)
+                return "", MsgDefault
+        }
+        cleaned, you := stripBEPPTags(textBytes)
+        text := strings.TrimSpace(decodeMacRoman(cleaned))
+        if text == "" {
+                return "", MsgDefault
+        }
+        class := MsgDefault
+        switch prefix {
+        case "th":
+                class = MsgInfo
+                if you {
+                        class = MsgMySpeech
+                        text = "You think: " + text
+                } else {
+                        text = "think: " + text
+                }
+        case "in":
+                class = MsgInfo
+                text = "info: " + text
+        case "sh":
+                class = MsgShare
+                if you {
+                        class = MsgMySpeech
+                        text = "You share: " + text
+                } else {
+                        text = "share: " + text
+                }
+        case "lg":
+                class = MsgLogon
+        case "lf":
+                class = MsgLogoff
+        case "er":
+                class = MsgError
+        default:
+                class = MsgDefault
+        }
+        return text, class
 }
 
-func stripBEPPTags(b []byte) []byte {
-	out := b[:0]
-	for i := 0; i < len(b); {
-		c := b[i]
-		if c == 0xC2 {
-			if i+2 < len(b) {
-				i += 3
-				continue
-			}
-			break
-		}
-		if c >= 0x80 || c < 0x20 {
-			i++
-			continue
-		}
-		out = append(out, c)
-		i++
-	}
-	return out
+func stripBEPPTags(b []byte) ([]byte, bool) {
+        out := b[:0]
+        you := false
+        for i := 0; i < len(b); {
+                c := b[i]
+                if c == 0xC2 {
+                        if i+2 >= len(b) {
+                                break
+                        }
+                        tag := string(b[i+1 : i+3])
+                        i += 3
+                        if tag == "pn" {
+                                end := bytes.Index(b[i:], []byte{0xC2, 'p', 'n'})
+                                if end < 0 {
+                                        continue
+                                }
+                                name := strings.TrimSpace(decodeMacRoman(b[i : i+end]))
+                                if strings.EqualFold(name, playerName) {
+                                        out = append(out, []byte("You")...)
+                                        you = true
+                                } else {
+                                        out = append(out, []byte(name)...)
+                                }
+                                i += end + 3
+                        }
+                        continue
+                }
+                if c >= 0x80 || c < 0x20 {
+                        i++
+                        continue
+                }
+                out = append(out, c)
+                i++
+        }
+        return out, you
 }
 
 func decodeBubble(data []byte) string {
@@ -89,7 +125,7 @@ func decodeBubble(data []byte) string {
 	if len(data) <= p {
 		return ""
 	}
-	msgData := stripBEPPTags(data[p:])
+        msgData, _ := stripBEPPTags(data[p:])
 	if i := bytes.IndexByte(msgData, 0); i >= 0 {
 		msgData = msgData[:i]
 	}
@@ -138,12 +174,12 @@ func decodeMessage(m []byte) string {
 		return ""
 	}
 	data := append([]byte(nil), m[16:]...)
-	if len(data) > 0 && data[0] == 0xC2 {
-		if s := decodeBEPP(data); s != "" {
-			return s
-		}
-		return ""
-	}
+        if len(data) > 0 && data[0] == 0xC2 {
+                if s, _ := decodeBEPP(data); s != "" {
+                        return s
+                }
+                return ""
+        }
 	if s := decodeBubble(data); s != "" {
 		return s
 	}
@@ -157,13 +193,13 @@ func decodeMessage(m []byte) string {
 		}
 	}
 
-	simpleEncrypt(data)
-	if len(data) > 0 && data[0] == 0xC2 {
-		if s := decodeBEPP(data); s != "" {
-			return s
-		}
-		return ""
-	}
+        simpleEncrypt(data)
+        if len(data) > 0 && data[0] == 0xC2 {
+                if s, _ := decodeBEPP(data); s != "" {
+                        return s
+                }
+                return ""
+        }
 	if s := decodeBubble(data); s != "" {
 		return s
 	}
@@ -184,29 +220,30 @@ func handleInfoText(data []byte) {
 		if len(line) == 0 {
 			continue
 		}
-		if line[0] == 0xC2 {
-			if txt := decodeBEPP(line); txt != "" {
-				fmt.Println(txt)
-				addMessage(txt)
-			}
-			continue
-		}
-		if txt := decodeBubble(line); txt != "" {
-			fmt.Println(txt)
-			addMessage(txt)
-			continue
-		}
-		s := strings.TrimSpace(decodeMacRoman(stripBEPPTags(line)))
-		if s == "" {
-			continue
-		}
-		if parseNightCommand(s) {
-			continue
-		}
-		if strings.HasPrefix(s, "/") {
-			continue
-		}
-		fmt.Println(s)
-		addMessage(s)
-	}
+                if line[0] == 0xC2 {
+                        if txt, class := decodeBEPP(line); txt != "" {
+                                fmt.Println(txt)
+                                addMessage(class, txt)
+                        }
+                        continue
+                }
+                if txt := decodeBubble(line); txt != "" {
+                        fmt.Println(txt)
+                        addMessage(MsgDefault, txt)
+                        continue
+                }
+                sBytes, _ := stripBEPPTags(line)
+                s := strings.TrimSpace(decodeMacRoman(sBytes))
+                if s == "" {
+                        continue
+                }
+                if parseNightCommand(s) {
+                        continue
+                }
+                if strings.HasPrefix(s, "/") {
+                        continue
+                }
+                fmt.Println(s)
+                addMessage(MsgDefault, s)
+        }
 }

--- a/go_client/decode_test.go
+++ b/go_client/decode_test.go
@@ -20,7 +20,7 @@ func TestDecodeBubbleEmptyAfterStripping(t *testing.T) {
 func TestParseBackendInfo(t *testing.T) {
 	players = make(map[string]*Player)
 	data := []byte("\xc2be\xc2in\xc2pnAlice\xc2pn\tHuman\tFemale\tFighter\t")
-	decodeBEPP(data)
+        _, _ = decodeBEPP(data)
 	p := players["Alice"]
 	if p == nil || p.Class != "Fighter" || p.Race != "Human" {
 		t.Fatalf("unexpected player: %#v", p)
@@ -30,7 +30,7 @@ func TestParseBackendInfo(t *testing.T) {
 func TestParseBackendShare(t *testing.T) {
 	players = make(map[string]*Player)
 	data := []byte("\xc2be\xc2sh\xc2pnAlice\xc2pn,\xc2pnBob\xc2pn\t\xc2pnCarol\xc2pn")
-	decodeBEPP(data)
+        _, _ = decodeBEPP(data)
 	if !players["Alice"].Sharee || !players["Bob"].Sharee || !players["Carol"].Sharing {
 		t.Fatalf("share parsing failed: %#v", players)
 	}

--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -414,7 +414,7 @@ func parseDrawState(data []byte) bool {
 				return false
 			}
 			bubbleData := stateData[:p+end+1]
-			if txt := decodeBubble(bubbleData); txt != "" {
+                                if txt := decodeBubble(bubbleData); txt != "" {
 				name := ""
 				stateMu.Lock()
 				if d, ok := state.descriptors[idx]; ok {
@@ -426,10 +426,8 @@ func parseDrawState(data []byte) bool {
 					msg = name + " " + txt
 				}
 				fmt.Println(msg)
-				if idx != playerIndex {
-					addMessage(msg)
-				}
-			}
+                                addMessage(MsgDefault, msg)
+                                }
 			stateData = stateData[p+end+1:]
 		}
 	}

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -410,11 +410,11 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	x += barWidth + gap
 	drawBar(x, sp, spMax, color.RGBA{0x00, 0x00, 0xff, 0xff})
 
-	msgs := getMessages()
-	startY := 480*scale - 12*len(msgs)*scale - 6*scale
-	for i, msg := range msgs {
-		ebitenutil.DebugPrintAt(screen, msg, 4*scale, startY+12*i*scale)
-	}
+        msgs := getMessages()
+        startY := 480*scale - 12*len(msgs)*scale - 6*scale
+        for i, msg := range msgs {
+                ebitenutil.DebugPrintAt(screen, msg.Text, 4*scale, startY+12*i*scale)
+        }
 	if inputActive {
 		if inputBg == nil {
 			inputBg = ebiten.NewImage(gameAreaSizeX*scale, 12*scale)
@@ -480,9 +480,9 @@ func udpReadLoop(ctx context.Context, conn net.Conn) {
 			handleDrawState(m)
 			continue
 		}
-		if txt := decodeMessage(m); txt != "" {
-			fmt.Println(txt)
-			addMessage(txt)
+                if txt := decodeMessage(m); txt != "" {
+                        fmt.Println(txt)
+                        addMessage(MsgDefault, txt)
 		} else {
 			fmt.Printf("udp msg tag %d len %d\n", tag, len(m))
 		}
@@ -514,9 +514,9 @@ loop:
 			handleDrawState(m)
 			continue
 		}
-		if txt := decodeMessage(m); txt != "" {
-			fmt.Println(txt)
-			addMessage(txt)
+                if txt := decodeMessage(m); txt != "" {
+                        fmt.Println(txt)
+                        addMessage(MsgDefault, txt)
 		} else {
 			fmt.Printf("msg tag %d len %d\n", tag, len(m))
 		}
@@ -534,5 +534,5 @@ func sendChat(txt string) {
 			fmt.Printf("send chat: %v\n", err)
 		}
 	}
-	addMessage(txt)
+        addMessage(MsgMySpeech, txt)
 }

--- a/go_client/main.go
+++ b/go_client/main.go
@@ -41,7 +41,7 @@ func main() {
 	clImages, imgErr = climg.Load("CL_Images")
 	if imgErr != nil {
 		log.Printf("load CL_Images: %v", imgErr)
-		addMessage(fmt.Sprintf("load CL_Images: %v", imgErr))
+            addMessage(MsgDefault, fmt.Sprintf("load CL_Images: %v", imgErr))
 	}
 	if imgErr != nil && *clmov != "" {
 		alt := filepath.Join(filepath.Dir(*clmov), "CL_Images")
@@ -51,7 +51,7 @@ func main() {
 			log.Printf("loaded CL_Images from %s", alt)
 		} else {
 			log.Printf("load CL_Images from %s: %v", alt, err)
-			addMessage(fmt.Sprintf("load CL_Images from %s: %v", alt, err))
+                    addMessage(MsgDefault, fmt.Sprintf("load CL_Images from %s: %v", alt, err))
 		}
 	}
 

--- a/go_client/messages.go
+++ b/go_client/messages.go
@@ -4,22 +4,42 @@ import "sync"
 
 const maxMessages = 5
 
-var (
-	messageMu sync.Mutex
-	messages  []string
+type MsgClass int
+
+const (
+        MsgDefault MsgClass = iota
+        MsgInfo
+        MsgShare
+        MsgLogon
+        MsgLogoff
+        MsgError
+        MsgMySpeech
 )
 
-func addMessage(msg string) {
-	messageMu.Lock()
-	defer messageMu.Unlock()
-	messages = append(messages, msg)
-	if len(messages) > maxMessages {
-		messages = messages[len(messages)-maxMessages:]
-	}
+type Message struct {
+        Class MsgClass
+        Text  string
 }
 
-func getMessages() []string {
-	messageMu.Lock()
-	defer messageMu.Unlock()
-	return append([]string(nil), messages...)
+var (
+        messageMu sync.Mutex
+        messages  []Message
+)
+
+func addMessage(class MsgClass, msg string) {
+        messageMu.Lock()
+        defer messageMu.Unlock()
+        messages = append(messages, Message{Class: class, Text: msg})
+        if len(messages) > maxMessages {
+                messages = messages[len(messages)-maxMessages:]
+        }
 }
+
+func getMessages() []Message {
+        messageMu.Lock()
+        defer messageMu.Unlock()
+        out := make([]Message, len(messages))
+        copy(out, messages)
+        return out
+}
+


### PR DESCRIPTION
## Summary
- structure message log with classes like info, share, and my speech
- interpret BEP message prefixes and replace local player names with `You`
- process info text with updated BEP parsing

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d9e2bfba8832ab1beca5dd1c0669d