### PR TITLE
Preserve mobile info in draw state

### DIFF
--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -289,29 +289,14 @@ func parseDrawState(data []byte) bool {
 	state.spMax = spMax
 	state.balance = bal
 	state.balanceMax = balMax
-	changed := false
-	if onion {
-		if len(descs) > 0 {
-			changed = true
+	changed := len(descs) > 0 || len(mobiles) > 0
+	if onion && changed {
+		if state.prevDescs == nil {
+			state.prevDescs = make(map[uint8]frameDescriptor)
 		}
-		if len(mobiles) != len(state.mobiles) {
-			changed = true
-		} else {
-			for _, m := range mobiles {
-				if pm, ok := state.mobiles[m.Index]; !ok || pm.State != m.State {
-					changed = true
-					break
-				}
-			}
-		}
-		if changed {
-			if state.prevDescs == nil {
-				state.prevDescs = make(map[uint8]frameDescriptor)
-			}
-			state.prevDescs = make(map[uint8]frameDescriptor, len(state.descriptors))
-			for idx, d := range state.descriptors {
-				state.prevDescs[idx] = d
-			}
+		state.prevDescs = make(map[uint8]frameDescriptor, len(state.descriptors))
+		for idx, d := range state.descriptors {
+			state.prevDescs[idx] = d
 		}
 	}
 	if state.descriptors == nil {
@@ -372,11 +357,6 @@ func parseDrawState(data []byte) bool {
 
 	if state.mobiles == nil {
 		state.mobiles = make(map[uint8]frameMobile)
-	} else {
-		// clear map while keeping allocation
-		for k := range state.mobiles {
-			delete(state.mobiles, k)
-		}
 	}
 	for _, m := range mobiles {
 		state.mobiles[m.Index] = m
@@ -423,7 +403,7 @@ func parseDrawState(data []byte) bool {
 				return false
 			}
 			bubbleData := stateData[:p+end+1]
-                                if txt := decodeBubble(bubbleData); txt != "" {
+			if txt := decodeBubble(bubbleData); txt != "" {
 				name := ""
 				stateMu.Lock()
 				if d, ok := state.descriptors[idx]; ok {
@@ -435,8 +415,8 @@ func parseDrawState(data []byte) bool {
 					msg = name + " " + txt
 				}
 				fmt.Println(msg)
-                                addMessage(MsgDefault, msg)
-                                }
+				addMessage(MsgDefault, msg)
+			}
 			stateData = stateData[p+end+1:]
 		}
 	}

--- a/go_client/draw_test.go
+++ b/go_client/draw_test.go
@@ -44,3 +44,36 @@ func TestParseDrawStatePreservesName(t *testing.T) {
 		t.Fatalf("empty player name registered")
 	}
 }
+
+// TestParseDrawStatePreservesMobiles ensures that incoming draw state packets
+// with zero mobile entries do not clear previously known mobiles. Without this
+// behavior player names disappear during movie playback.
+func TestParseDrawStatePreservesMobiles(t *testing.T) {
+	debug = false
+	players = make(map[string]*Player)
+	state.descriptors = map[uint8]frameDescriptor{}
+	state.mobiles = map[uint8]frameMobile{
+		1: {Index: 1, H: 10, V: 20},
+	}
+
+	data := []byte{
+		0,          // ackCmd
+		0, 0, 0, 0, // ackFrame
+		0, 0, 0, 0, // resendFrame
+		0,                   // descCount
+		0, 0, 0, 0, 0, 0, 0, // stats (hp..lighting)
+		0, // pictCount
+		0, // mobileCount
+		0, // info text terminator
+		0, // bubble count
+	}
+	msg := make([]byte, 2+len(data))
+	binary.BigEndian.PutUint16(msg[:2], 2)
+	copy(msg[2:], data)
+
+	handleDrawState(msg)
+
+	if len(state.mobiles) != 1 {
+		t.Fatalf("mobiles cleared: %#v", state.mobiles)
+	}
+}


### PR DESCRIPTION
## Summary
- keep previously known mobiles when draw state packets contain no mobiles
- simplify change detection logic for onion mode
- add regression test to ensure mobiles persist across frames

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688da271b2d8832a8e00ff9d46198cbe