### PR TITLE
Send input text to server

### DIFF
--- a/go_client/game.go
+++ b/go_client/game.go
@@ -84,7 +84,7 @@ func (g *Game) Update() error {
 		if inpututil.IsKeyJustPressed(ebiten.KeyEnter) {
 			txt := strings.TrimSpace(string(inputText))
 			if txt != "" {
-				sendChat(txt)
+				sendCommand(txt)
 			}
 			inputActive = false
 			inputText = inputText[:0]
@@ -521,11 +521,10 @@ loop:
 	}
 }
 
-func sendChat(txt string) {
+func sendCommand(txt string) {
 	if tcpConn != nil {
 		if err := sendCommandText(tcpConn, txt); err != nil {
-			fmt.Printf("send chat: %v\n", err)
+			fmt.Printf("send command: %v\n", err)
 		}
 	}
-	addMessage(txt)
 }


### PR DESCRIPTION
## Summary
- forward typed input to server commands rather than local chat echo

## Testing
- `go test ./... -run TestParseMovie -v` *(fails: glfw: X11: The DISPLAY environment variable is missing)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688da87fd660832ab8e26eaea47fddce