### PR TITLE
Parse movie headers and validate compatibility

### DIFF
--- a/go_client/main.go
+++ b/go_client/main.go
@@ -56,7 +56,7 @@ func main() {
 	}
 
 	if *clmov != "" {
-		frames, err := parseMovie(*clmov)
+		frames, err := parseMovie(*clmov, *clientVer)
 		if err != nil {
 			log.Fatalf("parse movie: %v", err)
 		}

--- a/go_client/movie.go
+++ b/go_client/movie.go
@@ -17,7 +17,9 @@ const (
 const movieSignature = 0xdeadbeef
 const oldestMovieVersion = 193
 
-func parseMovie(path string) ([][]byte, error) {
+var movieRevision int32
+
+func parseMovie(path string, clientVersion int) ([][]byte, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -40,7 +42,24 @@ func parseMovie(path string) ([][]byte, error) {
 	if headerLen <= 0 || headerLen > len(data) {
 		headerLen = 24
 	}
-	dlog("movie version %d headerLen %d", version, headerLen)
+	if len(data) < headerLen {
+		return nil, fmt.Errorf("short file")
+	}
+	frameCount := int32(binary.BigEndian.Uint32(data[8:12]))
+	startTime := binary.BigEndian.Uint32(data[12:16])
+	var revision, oldestReader int32
+	if headerLen >= 24 {
+		if len(data) < 24 {
+			return nil, fmt.Errorf("short file")
+		}
+		revision = int32(binary.BigEndian.Uint32(data[16:20]))
+		oldestReader = int32(binary.BigEndian.Uint32(data[20:24]))
+	}
+	movieRevision = revision
+	if oldestReader != 0 && oldestReader > int32(clientVersion) {
+		return nil, fmt.Errorf("movie requires newer client: %d", oldestReader)
+	}
+	dlog("movie version %d headerLen %d frames %d starttime %d revision %d oldestReader %d", version, headerLen, frameCount, startTime, revision, oldestReader)
 	pos := headerLen
 	sign := []byte{0xde, 0xad, 0xbe, 0xef}
 	frames := [][]byte{}
@@ -70,7 +89,7 @@ func parseMovie(path string) ([][]byte, error) {
 		}
 		if flags&flagMobileData != 0 {
 			dlog("MobileData table at %d", pos)
-			pos = parseMobileTable(data, pos)
+			pos = parseMobileTable(data, pos, revision)
 			continue
 		}
 		if flags&flagPictureTable != 0 {
@@ -114,7 +133,8 @@ func parseMovie(path string) ([][]byte, error) {
 	return frames, nil
 }
 
-func parseMobileTable(data []byte, pos int) int {
+func parseMobileTable(data []byte, pos int, revision int32) int {
+	_ = revision
 	const (
 		descTableSize = 266
 		descSize      = 156

--- a/go_client/movie_test.go
+++ b/go_client/movie_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/binary"
+	"os"
+	"strings"
+	"testing"
+)
+
+func writeHeader(t *testing.T, revision, oldestReader int32) string {
+	t.Helper()
+	data := make([]byte, 24)
+	binary.BigEndian.PutUint32(data[0:4], movieSignature)
+	binary.BigEndian.PutUint16(data[4:6], 200)
+	binary.BigEndian.PutUint16(data[6:8], 24)
+	binary.BigEndian.PutUint32(data[16:20], uint32(revision))
+	binary.BigEndian.PutUint32(data[20:24], uint32(oldestReader))
+	f, err := os.CreateTemp("", "clmovie-*.clMov")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		t.Fatalf("Write: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	return f.Name()
+}
+
+func TestParseMovieRejectsTooNew(t *testing.T) {
+	path := writeHeader(t, 0, 1450)
+	defer os.Remove(path)
+	if _, err := parseMovie(path, 1440); err == nil || !strings.Contains(err.Error(), "newer") {
+		t.Fatalf("expected newer client error, got %v", err)
+	}
+}
+
+func TestParseMovieStoresRevision(t *testing.T) {
+	path := writeHeader(t, 7, 1400)
+	defer os.Remove(path)
+	movieRevision = 0
+	if _, err := parseMovie(path, 1440); err != nil {
+		t.Fatalf("parseMovie: %v", err)
+	}
+	if movieRevision != 7 {
+		t.Fatalf("movieRevision = %d", movieRevision)
+	}
+}


### PR DESCRIPTION
## Summary
- Parse movie headers for frame count, start time, revision and oldest reader and reject movies requiring a newer client
- Share header revision with mobile-table parsing for future format handling and expose client version to `parseMovie`
- Add tests covering revision storage and too-new movie rejection

## Testing
- `xvfb-run go test ./... -run TestParseMovie -v`


------
https://chatgpt.com/codex/tasks/task_e_688daf082370832a98f2a14bcc0a0c10