### PR TITLE
Extend alpha mapping for sprite flags

### DIFF
--- a/go_client/climg/climg.go
+++ b/go_client/climg/climg.go
@@ -180,6 +180,32 @@ func Load(path string) (*CLImages, error) {
 	return imgs, nil
 }
 
+// alphaTransparentForFlags returns the base alpha value and whether
+// color index 0 should be treated as fully transparent for the given
+// sprite flags. The mapping mirrors the original client logic in
+// GameWin_cl.cp where specific flag combinations select distinct
+// alpha maps.
+func alphaTransparentForFlags(flags uint32) (uint8, bool) {
+        switch flags & (pictDefFlagTransparent | pictDefBlendMask) {
+        case pictDefFlagTransparent:
+                return 0xFF, true // kPictDefFlagTransparent
+        case 1:
+                return 0xBF, false // kPictDef25Blend
+        case 2:
+                return 0x7F, false // kPictDef50Blend
+        case 3:
+                return 0x3F, false // kPictDef75Blend
+        case pictDefFlagTransparent | 1:
+                return 0xBF, true // kPictDefFlagTransparent + kPictDef25Blend
+        case pictDefFlagTransparent | 2:
+                return 0x7F, true // kPictDefFlagTransparent + kPictDef50Blend
+        case pictDefFlagTransparent | 3:
+                return 0x3F, true // kPictDefFlagTransparent + kPictDef75Blend
+        default:
+                return 0xFF, false // kPictDefNoBlend or unknown
+        }
+}
+
 func (c *CLImages) Get(id uint32) *ebiten.Image {
 	c.mu.Lock()
 	if img, ok := c.cache[id]; ok {
@@ -293,19 +319,12 @@ func (c *CLImages) Get(id uint32) *ebiten.Image {
 			height--
 		}
 	}
-	pixelCount = len(data)
-	img := image.NewRGBA(image.Rect(0, 0, width, height))
+       pixelCount = len(data)
+       img := image.NewRGBA(image.Rect(0, 0, width, height))
 
-	alpha := uint8(255)
-	switch ref.flags & pictDefBlendMask {
-	case 1:
-		alpha = 0xBF
-	case 2:
-		alpha = 0x7F
-	case 3:
-		alpha = 0x3F
-	}
-	transparent := (ref.flags & pictDefFlagTransparent) != 0
+       // Determine alpha level and transparency handling based on
+       // sprite definition flags.
+       alpha, transparent := alphaTransparentForFlags(ref.flags)
 
 	for i := 0; i < pixelCount; i++ {
 		idx := col[data[i]]

--- a/go_client/climg/climg_test.go
+++ b/go_client/climg/climg_test.go
@@ -1,0 +1,50 @@
+package climg
+
+import "testing"
+
+func applyAlpha(idx uint16, alpha uint8, transparent bool) uint8 {
+    if idx == 0 && transparent {
+        return 0
+    }
+    return alpha
+}
+
+func TestAlphaTransparentForFlags(t *testing.T) {
+    cases := []struct {
+        name       string
+        flags      uint32
+        alpha      uint8
+        transparent bool
+    }{
+        {"NoBlend", 0, 0xFF, false},
+        {"Transparent", pictDefFlagTransparent, 0xFF, true},
+        {"Blend25", 1, 0xBF, false},
+        {"Blend50", 2, 0x7F, false},
+        {"Blend75", 3, 0x3F, false},
+        {"Transparent25", pictDefFlagTransparent | 1, 0xBF, true},
+        {"Transparent50", pictDefFlagTransparent | 2, 0x7F, true},
+        {"Transparent75", pictDefFlagTransparent | 3, 0x3F, true},
+    }
+
+    for _, tt := range cases {
+        alpha, transparent := alphaTransparentForFlags(tt.flags)
+        if alpha != tt.alpha || transparent != tt.transparent {
+            t.Errorf("%s: got alpha=%#x transparent=%v", tt.name, alpha, transparent)
+        }
+
+        a0 := applyAlpha(0, alpha, transparent)
+        want0 := tt.alpha
+        if tt.transparent {
+            want0 = 0
+        }
+        if a0 != want0 {
+            t.Errorf("%s: index0 alpha=%#x want %#x", tt.name, a0, want0)
+        }
+
+        a1 := applyAlpha(1, alpha, transparent)
+        if a1 != tt.alpha {
+            t.Errorf("%s: index1 alpha=%#x want %#x", tt.name, a1, tt.alpha)
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Implement alphaTransparentForFlags to mirror GameWin_cl.cp logic
- Apply new alpha/transparency handling in image decoding
- Add tests covering blend and transparency combinations

## Testing
- `go mod download`
- `go test ./climg` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688db40c28f0832abb26a70e08cfe917