### PR TITLE
test: pass client version to parseMovie

### DIFF
--- a/go_client/decode_test.go
+++ b/go_client/decode_test.go
@@ -42,7 +42,7 @@ func TestParseBackendShare(t *testing.T) {
 func TestParseMovieNames(t *testing.T) {
 	state.descriptors = nil
 	state.mobiles = nil
-	if _, err := parseMovie("test.clMov"); err != nil {
+	if _, err := parseMovie("test.clMov", 1440); err != nil {
 		t.Fatalf("parseMovie: %v", err)
 	}
 	found := false


### PR DESCRIPTION
## Summary
- pass client version argument to `parseMovie` in `TestParseMovieNames`

## Testing
- `xvfb-run -a go test -run TestParseMovieNames -v | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688db68695c8832abea58ace014a9c11