### PR TITLE
Refine area change detection for draw updates

### DIFF
--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -344,7 +344,20 @@ func parseDrawState(data []byte) bool {
 			dlog("new  pics: %s", picturesSummary(newPics))
 		}
 	}
-	newArea := pictAgain == 0
+	prevAck := state.lastAckFrame
+	prevResend := state.lastResendFrame
+	newArea := false
+	if pictAgain == 0 {
+		if len(prevPics) == 0 {
+			newArea = true
+		} else if ackFrame == 0 && resendFrame == 0 {
+			newArea = true
+		} else if ackFrame < prevAck || resendFrame < prevResend {
+			newArea = true
+		}
+	}
+	state.lastAckFrame = ackFrame
+	state.lastResendFrame = resendFrame
 	if newArea {
 		state.picShiftX = 0
 		state.picShiftY = 0

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -42,15 +42,17 @@ var drawFilter = ebiten.FilterNearest
 
 // drawState tracks information needed by the Ebiten renderer.
 type drawState struct {
-	descriptors map[uint8]frameDescriptor
-	pictures    []framePicture
-	picShiftX   int
-	picShiftY   int
-	mobiles     map[uint8]frameMobile
-	prevMobiles map[uint8]frameMobile
-	prevDescs   map[uint8]frameDescriptor
-	prevTime    time.Time
-	curTime     time.Time
+	descriptors     map[uint8]frameDescriptor
+	pictures        []framePicture
+	picShiftX       int
+	picShiftY       int
+	mobiles         map[uint8]frameMobile
+	prevMobiles     map[uint8]frameMobile
+	prevDescs       map[uint8]frameDescriptor
+	prevTime        time.Time
+	curTime         time.Time
+	lastAckFrame    int32
+	lastResendFrame int32
 
 	hp, hpMax           int
 	sp, spMax           int


### PR DESCRIPTION
## Summary
- Track last ack/resend frame numbers to identify real area transitions
- Preserve interpolation state when frames belong to the same area

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688dbca5a600832abfc421762b2f32b1