### PR TITLE
Try parsing movie frames before encrypting

### DIFF
--- a/go_client/main.go
+++ b/go_client/main.go
@@ -282,7 +282,6 @@ func extractMoviePlayerName(frames [][]byte) string {
 	for _, m := range frames {
 		if len(m) >= 2 && binary.BigEndian.Uint16(m[:2]) == 2 {
 			data := append([]byte(nil), m[2:]...)
-			simpleEncrypt(data)
 			if n := firstDescriptorName(data); n != "" {
 				return n
 			}


### PR DESCRIPTION
## Summary
- Try parsing unencrypted movie frames for the first descriptor name before encrypting frames

## Testing
- `go mod download`
- `go build -v`
- `go test ./...` *(fails: glfw: The GLFW library is not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_688dc11c8d4c832abc61f1e59df9210a