### PR TITLE
Revert area transition detection to picture-based motion

### DIFF
--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -30,9 +30,6 @@ type frameMobile struct {
 
 const poseDead = 32
 
-// pictureShiftFails counts picture shift failures for debugging.
-var pictureShiftFails int
-
 // bitReader helps decode the packed picture fields.
 type bitReader struct {
 	data   []byte
@@ -335,35 +332,22 @@ func parseDrawState(data []byte) bool {
 	copy(newPics, prevPics[:again])
 	copy(newPics[again:], pics)
 	shiftOK := true
-	dx, dy := 0, 0
 	if interp {
-		dx, dy, shiftOK = pictureShift(prevPics, newPics)
-		dlog("interp pictures again=%d prev=%d cur=%d shift=(%d,%d) ok=%t", again, len(prevPics), len(newPics), dx, dy, shiftOK)
-		if !shiftOK {
+		var ok bool
+		dx, dy, ok := pictureShift(prevPics, newPics)
+		dlog("interp pictures again=%d prev=%d cur=%d shift=(%d,%d) ok=%t", again, len(prevPics), len(newPics), dx, dy, ok)
+		if !ok {
 			dlog("prev pics: %s", picturesSummary(prevPics))
 			dlog("new  pics: %s", picturesSummary(newPics))
+			state.picShiftX = 0
+			state.picShiftY = 0
+		} else {
+			state.picShiftX = dx
+			state.picShiftY = dy
 		}
+		shiftOK = ok
 	}
-	prevPlayer, okPrev := state.mobiles[playerIndex]
-	curPlayer := frameMobile{}
-	okCur := false
-	for _, m := range mobiles {
-		if m.Index == playerIndex {
-			curPlayer = m
-			okCur = true
-			break
-		}
-	}
-	newArea := true
-	if okPrev && okCur {
-		dx := int(curPlayer.H) - int(prevPlayer.H)
-		dy := int(curPlayer.V) - int(prevPlayer.V)
-		if dx*dx+dy*dy <= 64*64 {
-			newArea = false
-		}
-	}
-	state.lastAckFrame = ackFrame
-	state.lastResendFrame = resendFrame
+	newArea := pictAgain == 0 || !shiftOK
 	if newArea {
 		state.picShiftX = 0
 		state.picShiftY = 0
@@ -374,37 +358,6 @@ func parseDrawState(data []byte) bool {
 		state.curTime = time.Time{}
 	} else {
 		state.pictures = newPics
-		if interp {
-			if shiftOK {
-				state.picShiftX = dx
-				state.picShiftY = dy
-			} else {
-				pictureShiftFails++
-				dlog("picture shift failed (%d)", pictureShiftFails)
-				prevPlayer, okPrev := state.mobiles[playerIndex]
-				curPlayer := frameMobile{}
-				okCur := false
-				for _, m := range mobiles {
-					if m.Index == playerIndex {
-						curPlayer = m
-						okCur = true
-						break
-					}
-				}
-				if okPrev && okCur {
-					state.picShiftX = int(curPlayer.H) - int(prevPlayer.H)
-					state.picShiftY = int(curPlayer.V) - int(prevPlayer.V)
-					dlog("player shift fallback dx=%d dy=%d", state.picShiftX, state.picShiftY)
-				} else {
-					state.picShiftX = 0
-					state.picShiftY = 0
-					dlog("player shift fallback unavailable prev=%t cur=%t", okPrev, okCur)
-				}
-			}
-		} else {
-			state.picShiftX = 0
-			state.picShiftY = 0
-		}
 	}
 
 	needAnimUpdate := !newArea && (interp || (onion && changed))

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -42,17 +42,15 @@ var drawFilter = ebiten.FilterNearest
 
 // drawState tracks information needed by the Ebiten renderer.
 type drawState struct {
-	descriptors     map[uint8]frameDescriptor
-	pictures        []framePicture
-	picShiftX       int
-	picShiftY       int
-	mobiles         map[uint8]frameMobile
-	prevMobiles     map[uint8]frameMobile
-	prevDescs       map[uint8]frameDescriptor
-	prevTime        time.Time
-	curTime         time.Time
-	lastAckFrame    int32
-	lastResendFrame int32
+	descriptors map[uint8]frameDescriptor
+	pictures    []framePicture
+	picShiftX   int
+	picShiftY   int
+	mobiles     map[uint8]frameMobile
+	prevMobiles map[uint8]frameMobile
+	prevDescs   map[uint8]frameDescriptor
+	prevTime    time.Time
+	curTime     time.Time
 
 	hp, hpMax           int
 	sp, spMax           int


### PR DESCRIPTION
## Summary
- drop lastAckFrame/lastResendFrame tracking
- revert draw loop to rely solely on picture-based shifts

## Testing
- `go build -v ./...`
- `go test ./... -run TestParseMovie -v` *(fails: GLFW library is not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_688dc221436c832a8dc2640a29cdacee