### PR TITLE
Limit motion interpolation to small moves

### DIFF
--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -29,6 +29,7 @@ type frameMobile struct {
 }
 
 const poseDead = 32
+const maxInterpPixels = 64
 
 // sanity limits for parsed counts to avoid excessive allocations or
 // obviously corrupt packets.
@@ -148,6 +149,10 @@ func pictureShift(prev, cur []framePicture) (int, int, bool) {
 	dlog("pictureShift: counts=%v best=%v count=%d total=%d", counts, best, bestCount, total)
 	if bestCount*2 <= total {
 		dlog("pictureShift: no majority best=%d total=%d", bestCount, total)
+		return 0, 0, false
+	}
+	if best[0]*best[0]+best[1]*best[1] > maxInterpPixels*maxInterpPixels {
+		dlog("pictureShift: motion too large (%d,%d)", best[0], best[1])
 		return 0, 0, false
 	}
 	return best[0], best[1], true

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -206,8 +206,12 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		v := float64(m.V)
 		if interp {
 			if pm, ok := prevMobiles[m.Index]; ok {
-				h = float64(pm.H)*(1-alpha) + float64(m.H)*alpha
-				v = float64(pm.V)*(1-alpha) + float64(m.V)*alpha
+				dh := int(m.H) - int(pm.H)
+				dv := int(m.V) - int(pm.V)
+				if dh*dh+dv*dv <= maxInterpPixels*maxInterpPixels {
+					h = float64(pm.H)*(1-alpha) + float64(m.H)*alpha
+					v = float64(pm.V)*(1-alpha) + float64(m.V)*alpha
+				}
 			}
 		}
 		x := (int(math.Round(h)) + fieldCenterX) * scale


### PR DESCRIPTION
## Summary
- avoid picture interpolation when estimated movement exceeds 64 pixels
- skip mobile interpolation when distance between frames is over 64 pixels

## Testing
- `go build ./...`
- `go test ./... -run TestParseMovie -v` *(fails: X11 DISPLAY missing)*

------
https://chatgpt.com/codex/tasks/task_e_688dc6bc1720832a8dd25c90c894aae0