### PR TITLE
Persist player color customization across frames

### DIFF
--- a/go_client/game.go
+++ b/go_client/game.go
@@ -214,7 +214,11 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		y := (int(math.Round(v)) + fieldCenterY) * scale
 		var img *ebiten.Image
 		if d, ok := descMap[m.Index]; ok {
-			img = loadMobileFrame(d.PictID, m.State)
+			colors := d.Colors
+			if p := getPlayer(d.Name); p != nil && len(p.Colors) > 0 {
+				colors = p.Colors
+			}
+			img = loadMobileFrame(d.PictID, m.State, colors)
 		}
 		var prevImg *ebiten.Image
 		if onion {
@@ -223,7 +227,11 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				if d, ok := prevDescs[m.Index]; ok {
 					pd = d
 				}
-				prevImg = loadMobileFrame(pd.PictID, pm.State)
+				prevColors := pd.Colors
+				if p := getPlayer(pd.Name); p != nil && len(p.Colors) > 0 {
+					prevColors = p.Colors
+				}
+				prevImg = loadMobileFrame(pd.PictID, pm.State, prevColors)
 			}
 		}
 		if img != nil {

--- a/go_client/images.go
+++ b/go_client/images.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"image"
 	"image/color"
 	"log"
@@ -20,9 +21,9 @@ var (
 	// sheetCache holds the full sprite sheet for a picture ID. These are
 	// used when extracting individual mobile frames.
 	sheetCache = make(map[uint16]*ebiten.Image)
-	// mobileCache caches individual mobile frames keyed by picture ID and
-	// state.
-	mobileCache = make(map[uint32]*ebiten.Image)
+	// mobileCache caches individual mobile frames keyed by picture ID,
+	// state, and color overrides.
+	mobileCache = make(map[string]*ebiten.Image)
 
 	imageMu  sync.Mutex
 	clImages *climg.CLImages
@@ -99,9 +100,10 @@ func loadImage(id uint16) *ebiten.Image {
 }
 
 // loadMobileFrame retrieves a cropped frame from a mobile sprite sheet based on
-// the state value provided by the server.
-func loadMobileFrame(id uint16, state uint8) *ebiten.Image {
-	key := uint32(id)<<8 | uint32(state)
+// the state value provided by the server. The optional colors slice allows
+// caller-supplied palette overrides to be cached separately.
+func loadMobileFrame(id uint16, state uint8, colors []byte) *ebiten.Image {
+	key := fmt.Sprintf("%d-%d-%x", id, state, colors)
 	imageMu.Lock()
 	if img, ok := mobileCache[key]; ok {
 		imageMu.Unlock()

--- a/go_client/player.go
+++ b/go_client/player.go
@@ -27,5 +27,7 @@ func getPlayer(name string) *Player {
 func updatePlayerAppearance(name string, pictID uint16, colors []byte) {
 	p := getPlayer(name)
 	p.PictID = pictID
-	p.Colors = append(p.Colors[:0], colors...)
+	if len(colors) > 0 {
+		p.Colors = append(p.Colors[:0], colors...)
+	}
 }


### PR DESCRIPTION
## Summary
- Preserve a player's most recent custom colors when their appearance is updated.
- Reuse stored player colors during rendering and pass them to `loadMobileFrame`.
- Cache mobile frames by ID, state, and colors for consistent recoloring.

## Testing
- `go test ./...` *(fails: X11 DISPLAY variable missing)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688dc6718e50832a946b18b6861b1cb5