### PR TITLE
Identify player descriptor from movie

### DIFF
--- a/go_client/main.go
+++ b/go_client/main.go
@@ -263,6 +263,15 @@ func main() {
 
 func extractMoviePlayerName(frames [][]byte) string {
 	stateMu.Lock()
+	for idx, m := range state.mobiles {
+		if m.H == 0 && m.V == 0 {
+			if d, ok := state.descriptors[idx]; ok && d.Type == kDescPlayer {
+				playerIndex = idx
+				stateMu.Unlock()
+				return d.Name
+			}
+		}
+	}
 	if len(state.descriptors) > 0 {
 		var (
 			best uint8 = 0xff

--- a/go_client/util.go
+++ b/go_client/util.go
@@ -29,7 +29,10 @@ func simpleEncrypt(data []byte) {
 
 func encodeFullVersion(v int) uint32 { return uint32(v) << 8 }
 
-const baseVersion = 1353
+const (
+	baseVersion = 1353
+	kDescPlayer = 1
+)
 
 func hexDump(prefix string, data []byte) {
 	if !debug {


### PR DESCRIPTION
## Summary
- add `kDescPlayer` constant for player descriptors
- detect and return player name via mobiles + descriptors before fallback

## Testing
- `go build ./...`
- `go test ./... -run TestParseMovie -v` *(fails: X11 DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688dca0bbadc832aa44471a2459727f4