### PR TITLE
Render mobiles with custom palettes

### DIFF
--- a/go_client/climg/climg.go
+++ b/go_client/climg/climg.go
@@ -40,7 +40,7 @@ type CLImages struct {
 	idrefs map[uint32]*dataLocation
 	colors map[uint32]*dataLocation
 	images map[uint32]*dataLocation
-	cache  map[uint32]*ebiten.Image
+	cache  map[string]*ebiten.Image
 	mu     sync.Mutex
 }
 
@@ -85,7 +85,7 @@ func Load(path string) (*CLImages, error) {
 		idrefs: make(map[uint32]*dataLocation, entryCount),
 		colors: make(map[uint32]*dataLocation, entryCount),
 		images: make(map[uint32]*dataLocation, entryCount),
-		cache:  make(map[uint32]*ebiten.Image),
+		cache:  make(map[string]*ebiten.Image),
 	}
 
 	for i := uint32(0); i < entryCount; i++ {
@@ -186,29 +186,30 @@ func Load(path string) (*CLImages, error) {
 // GameWin_cl.cp where specific flag combinations select distinct
 // alpha maps.
 func alphaTransparentForFlags(flags uint32) (uint8, bool) {
-        switch flags & (pictDefFlagTransparent | pictDefBlendMask) {
-        case pictDefFlagTransparent:
-                return 0xFF, true // kPictDefFlagTransparent
-        case 1:
-                return 0xBF, false // kPictDef25Blend
-        case 2:
-                return 0x7F, false // kPictDef50Blend
-        case 3:
-                return 0x3F, false // kPictDef75Blend
-        case pictDefFlagTransparent | 1:
-                return 0xBF, true // kPictDefFlagTransparent + kPictDef25Blend
-        case pictDefFlagTransparent | 2:
-                return 0x7F, true // kPictDefFlagTransparent + kPictDef50Blend
-        case pictDefFlagTransparent | 3:
-                return 0x3F, true // kPictDefFlagTransparent + kPictDef75Blend
-        default:
-                return 0xFF, false // kPictDefNoBlend or unknown
-        }
+	switch flags & (pictDefFlagTransparent | pictDefBlendMask) {
+	case pictDefFlagTransparent:
+		return 0xFF, true // kPictDefFlagTransparent
+	case 1:
+		return 0xBF, false // kPictDef25Blend
+	case 2:
+		return 0x7F, false // kPictDef50Blend
+	case 3:
+		return 0x3F, false // kPictDef75Blend
+	case pictDefFlagTransparent | 1:
+		return 0xBF, true // kPictDefFlagTransparent + kPictDef25Blend
+	case pictDefFlagTransparent | 2:
+		return 0x7F, true // kPictDefFlagTransparent + kPictDef50Blend
+	case pictDefFlagTransparent | 3:
+		return 0x3F, true // kPictDefFlagTransparent + kPictDef75Blend
+	default:
+		return 0xFF, false // kPictDefNoBlend or unknown
+	}
 }
 
-func (c *CLImages) Get(id uint32) *ebiten.Image {
+func (c *CLImages) Get(id uint32, custom []byte) *ebiten.Image {
+	key := fmt.Sprintf("%d-%x", id, custom)
 	c.mu.Lock()
-	if img, ok := c.cache[id]; ok {
+	if img, ok := c.cache[key]; ok {
 		c.mu.Unlock()
 		return img
 	}
@@ -309,22 +310,23 @@ func (c *CLImages) Get(id uint32) *ebiten.Image {
 	pal := palette // from palette.go
 	col := append([]uint16(nil), colLoc.colorBytes...)
 
-	// Some sprites embed a row of color indices used to map per-mobile
-	// custom colors. The row is only needed when those overrides are
-	// applied, so for default rendering we simply drop it before
-	// constructing the final image.
+	var mapping []byte
 	if ref.flags&pictDefCustomColors != 0 {
 		if len(data) >= width {
+			mapping = data[:width]
 			data = data[width:]
 			height--
 		}
+		if len(custom) > 0 {
+			applyCustomPalette(col, mapping, custom)
+		}
 	}
-       pixelCount = len(data)
-       img := image.NewRGBA(image.Rect(0, 0, width, height))
+	pixelCount = len(data)
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
 
-       // Determine alpha level and transparency handling based on
-       // sprite definition flags.
-       alpha, transparent := alphaTransparentForFlags(ref.flags)
+	// Determine alpha level and transparency handling based on
+	// sprite definition flags.
+	alpha, transparent := alphaTransparentForFlags(ref.flags)
 
 	for i := 0; i < pixelCount; i++ {
 		idx := col[data[i]]
@@ -344,7 +346,7 @@ func (c *CLImages) Get(id uint32) *ebiten.Image {
 
 	eimg := ebiten.NewImageFromImage(img)
 	c.mu.Lock()
-	c.cache[id] = eimg
+	c.cache[key] = eimg
 	c.mu.Unlock()
 	return eimg
 }
@@ -356,6 +358,18 @@ func (c *CLImages) NumFrames(id uint32) int {
 		return int(ref.numFrames)
 	}
 	return 1
+}
+
+// applyCustomPalette replaces entries in col according to mapping and custom.
+// mapping holds color table indices for each customizable slot while custom
+// provides the new palette indices supplied by the server for those slots.
+func applyCustomPalette(col []uint16, mapping []byte, custom []byte) {
+	for i := 0; i < len(custom) && i < len(mapping); i++ {
+		idx := int(mapping[i])
+		if idx >= 0 && idx < len(col) {
+			col[idx] = uint16(custom[i])
+		}
+	}
 }
 
 // Plane returns the drawing plane for the given image ID. If unknown, it

--- a/go_client/climg/custom_test.go
+++ b/go_client/climg/custom_test.go
@@ -1,0 +1,13 @@
+package climg
+
+import "testing"
+
+func TestApplyCustomPalette(t *testing.T) {
+	col := []uint16{0, 1, 2, 3, 4}
+	mapping := []byte{2, 3}
+	custom := []byte{10, 11}
+	applyCustomPalette(col, mapping, custom)
+	if col[2] != 10 || col[3] != 11 {
+		t.Fatalf("unexpected palette: %v", col)
+	}
+}

--- a/go_client/images.go
+++ b/go_client/images.go
@@ -18,9 +18,10 @@ var (
 	// imageCache holds a cropped version of the first frame of an image. It
 	// is used for static pictures on the playfield.
 	imageCache = make(map[uint16]*ebiten.Image)
-	// sheetCache holds the full sprite sheet for a picture ID. These are
-	// used when extracting individual mobile frames.
-	sheetCache = make(map[uint16]*ebiten.Image)
+	// sheetCache holds the full sprite sheet for a picture ID and optional
+	// custom color palette. The key combines the picture ID with the custom
+	// color bytes so tinted versions are cached separately.
+	sheetCache = make(map[string]*ebiten.Image)
 	// mobileCache caches individual mobile frames keyed by picture ID,
 	// state, and color overrides.
 	mobileCache = make(map[string]*ebiten.Image)
@@ -44,18 +45,19 @@ func addBorder(img *ebiten.Image) *ebiten.Image {
 // loadImage retrieves the image for the specified picture ID. Images are
 // cached after the first load to avoid reopening files each frame.
 // loadSheet retrieves the full sprite sheet for the specified picture ID.
-func loadSheet(id uint16) *ebiten.Image {
+func loadSheet(id uint16, colors []byte) *ebiten.Image {
+	key := fmt.Sprintf("%d-%x", id, colors)
 	imageMu.Lock()
-	if img, ok := sheetCache[id]; ok {
+	if img, ok := sheetCache[key]; ok {
 		imageMu.Unlock()
 		return img
 	}
 	imageMu.Unlock()
 
 	if clImages != nil {
-		if img := clImages.Get(uint32(id)); img != nil {
+		if img := clImages.Get(uint32(id), colors); img != nil {
 			imageMu.Lock()
-			sheetCache[id] = img
+			sheetCache[key] = img
 			imageMu.Unlock()
 			return img
 		}
@@ -65,7 +67,7 @@ func loadSheet(id uint16) *ebiten.Image {
 	}
 
 	imageMu.Lock()
-	sheetCache[id] = nil
+	sheetCache[key] = nil
 	imageMu.Unlock()
 	return nil
 }
@@ -80,7 +82,7 @@ func loadImage(id uint16) *ebiten.Image {
 	}
 	imageMu.Unlock()
 
-	if sheet := loadSheet(id); sheet != nil {
+	if sheet := loadSheet(id, nil); sheet != nil {
 		frames := clImages.NumFrames(uint32(id))
 		if frames > 1 {
 			h := sheet.Bounds().Dy() / frames
@@ -111,7 +113,7 @@ func loadMobileFrame(id uint16, state uint8, colors []byte) *ebiten.Image {
 	}
 	imageMu.Unlock()
 
-	sheet := loadSheet(id)
+	sheet := loadSheet(id, colors)
 	if sheet == nil {
 		imageMu.Lock()
 		mobileCache[key] = nil


### PR DESCRIPTION
## Summary
- apply per-player color palettes when decoding sprite sheets
- cache tinted sprite sheets and frames using palette-specific keys
- add unit test for custom palette mapping

## Testing
- `go mod download`
- `go build ./...`
- `go test ./...` *(fails: X11 DISPLAY variable missing)*

------
https://chatgpt.com/codex/tasks/task_e_688dca5430bc832abd7b4227ef3ac151