### PR TITLE
Separate speech verb from bubble text

### DIFF
--- a/go_client/decode.go
+++ b/go_client/decode.go
@@ -68,33 +68,32 @@ func stripBEPPTags(b []byte) []byte {
 	return out
 }
 
-func decodeBubble(data []byte) string {
+func decodeBubble(data []byte) (verb, text string) {
 	if len(data) < 2 {
-		return ""
+		return "", ""
 	}
 	typ := int(data[1])
 	p := 2
 	if typ&kBubbleNotCommon != 0 {
 		if len(data) < p+1 {
-			return ""
+			return "", ""
 		}
 		p++
 	}
 	if typ&kBubbleFar != 0 {
 		if len(data) < p+4 {
-			return ""
+			return "", ""
 		}
 		p += 4
 	}
 	if len(data) <= p {
-		return ""
+		return "", ""
 	}
 	msgData := stripBEPPTags(data[p:])
 	if i := bytes.IndexByte(msgData, 0); i >= 0 {
 		msgData = msgData[:i]
 	}
 	lines := bytes.Split(msgData, []byte{'\r'})
-	var text string
 	for _, ln := range lines {
 		if len(ln) == 0 {
 			continue
@@ -113,24 +112,25 @@ func decodeBubble(data []byte) string {
 		}
 	}
 	if text == "" {
-		return ""
+		return "", ""
 	}
 	switch typ & kBubbleTypeMask {
 	case kBubbleNormal:
-		return "say: " + text
+		verb = "says"
 	case kBubbleWhisper:
-		return "whisper: " + text
+		verb = "whispers"
 	case kBubbleYell:
-		return "yell: " + text
+		verb = "yells"
 	case kBubbleThought:
-		return "think: " + text
+		verb = "thinks"
 	case kBubblePonder:
-		return "ponder: " + text
+		verb = "ponders"
 	case kBubbleNarrate:
-		return "console: " + text
+		// narrate bubbles have no verb
 	default:
-		return text
+		// unknown bubble types return no verb
 	}
+	return verb, text
 }
 
 func decodeMessage(m []byte) string {
@@ -144,7 +144,7 @@ func decodeMessage(m []byte) string {
 		}
 		return ""
 	}
-	if s := decodeBubble(data); s != "" {
+	if _, s := decodeBubble(data); s != "" {
 		return s
 	}
 	if i := bytes.IndexByte(data, 0); i >= 0 {
@@ -164,7 +164,7 @@ func decodeMessage(m []byte) string {
 		}
 		return ""
 	}
-	if s := decodeBubble(data); s != "" {
+	if _, s := decodeBubble(data); s != "" {
 		return s
 	}
 	if i := bytes.IndexByte(data, 0); i >= 0 {
@@ -191,7 +191,7 @@ func handleInfoText(data []byte) {
 			}
 			continue
 		}
-		if txt := decodeBubble(line); txt != "" {
+		if _, txt := decodeBubble(line); txt != "" {
 			fmt.Println(txt)
 			addMessage(txt)
 			continue

--- a/go_client/decode_test.go
+++ b/go_client/decode_test.go
@@ -2,21 +2,26 @@ package main
 
 import (
 	"encoding/binary"
+	"fmt"
 	"testing"
 )
 
 func TestDecodeBubbleStripsTags(t *testing.T) {
 	data := []byte{0x00, byte(kBubbleWhisper), 0x8A, 0xC2, 'p', 'n', ' ', 'p', 'i', 'n', 'g', '!', 0}
-	got := decodeBubble(data)
-	if got != "whisper: ping!" {
-		t.Fatalf("got %q", got)
+	verb, text := decodeBubble(data)
+	if verb != "whispers" || text != "ping!" {
+		t.Fatalf("got verb %q text %q", verb, text)
+	}
+	assembled := fmt.Sprintf("Bob %s, %q", verb, text)
+	if assembled != "Bob whispers, \"ping!\"" {
+		t.Fatalf("assembled %q", assembled)
 	}
 }
 
 func TestDecodeBubbleEmptyAfterStripping(t *testing.T) {
 	data := []byte{0x00, byte(kBubbleNormal), 0x8A, 0xC2, 'p', 'n', 0}
-	if got := decodeBubble(data); got != "" {
-		t.Fatalf("got %q", got)
+	if verb, txt := decodeBubble(data); verb != "" || txt != "" {
+		t.Fatalf("got %q %q", verb, txt)
 	}
 }
 

--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -460,16 +460,26 @@ func parseDrawState(data []byte) bool {
 			return false
 		}
 		bubbleData := stateData[:p+end+1]
-		if txt := decodeBubble(bubbleData); txt != "" {
+		if verb, txt := decodeBubble(bubbleData); txt != "" {
 			name := ""
 			stateMu.Lock()
 			if d, ok := state.descriptors[idx]; ok {
 				name = d.Name
 			}
 			stateMu.Unlock()
-			msg := txt
-			if name != "" {
-				msg = name + " " + txt
+			var msg string
+			if typ&kBubbleTypeMask == kBubbleNarrate {
+				if name != "" {
+					msg = fmt.Sprintf("(%s): %s", name, txt)
+				} else {
+					msg = txt
+				}
+			} else {
+				if name != "" {
+					msg = fmt.Sprintf("%s %s, %q", name, verb, txt)
+				} else {
+					msg = txt
+				}
 			}
 			fmt.Println(msg)
 			if idx != playerIndex {


### PR DESCRIPTION
## Summary
- Split bubble decoding into verb and message fields
- Assemble chat lines with verb and quoted text, handling narration specially
- Update tests for new verb/text separation

## Testing
- `EBITENGINE_HEADLESS=1 go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688dcea7b368832a8473b35c2187572e