### PR TITLE
Handle night info and render gradient

### DIFF
--- a/go_client/draw.go
+++ b/go_client/draw.go
@@ -249,7 +249,8 @@ func parseDrawState(data []byte) bool {
 	spMax := int(data[p+3])
 	bal := int(data[p+4])
 	balMax := int(data[p+5])
-	// lighting := data[p+6]
+	lighting := data[p+6]
+	gNight.SetFlags(uint(lighting))
 	p += 7
 
 	if len(data) <= p {

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -199,6 +199,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	alpha, fade := computeInterpolation(snap.prevTime, snap.curTime)
 	dlog("Draw alpha=%.2f shift=(%d,%d) pics=%d", alpha, snap.picShiftX, snap.picShiftY, len(snap.pictures))
 	drawScene(screen, snap, alpha, fade)
+	drawNightOverlay(screen)
 	drawStatusBars(screen, snap)
 	drawMessages(screen, getMessages())
 	if inputActive {

--- a/go_client/night.go
+++ b/go_client/night.go
@@ -1,21 +1,57 @@
 package main
 
 import (
+	"image/color"
+	"math"
 	"regexp"
 	"strconv"
 	"sync"
+
+	"github.com/hajimehoshi/ebiten/v2"
 )
 
 type NightInfo struct {
-	mu       sync.Mutex
-	Level    int
-	SunAngle int
-	Cloudy   bool
+	mu        sync.Mutex
+	BaseLevel int
+	Azimuth   int
+	Cloudy    bool
+	Flags     uint
+	Level     int
 }
 
 var gNight NightInfo
 
 var nightRE = regexp.MustCompile(`^/nt ([0-9]+) /sa ([-0-9]+) /cl ([01])`)
+
+func (n *NightInfo) calcCurLevel() {
+	delta := 0
+	if n.Flags&kLightNoNightMods != 0 {
+		n.Level = 0
+	} else {
+		if n.Flags&kLightAdjust25Pct != 0 {
+			delta += 25
+		}
+		if n.Flags&kLightAdjust50Pct != 0 {
+			delta += 50
+		}
+		if n.Flags&kLightAreaIsDarker != 0 {
+			delta = -delta
+		}
+		n.Level = n.BaseLevel - delta
+	}
+	if n.Level < 0 {
+		n.Level = 0
+	} else if n.Level > 100 {
+		n.Level = 100
+	}
+}
+
+func (n *NightInfo) SetFlags(f uint) {
+	n.mu.Lock()
+	n.Flags = f
+	n.calcCurLevel()
+	n.mu.Unlock()
+}
 
 func parseNightCommand(s string) bool {
 	m := nightRE.FindStringSubmatch(s)
@@ -26,9 +62,71 @@ func parseNightCommand(s string) bool {
 	sa, _ := strconv.Atoi(m[2])
 	cloudy := m[3] != "0"
 	gNight.mu.Lock()
-	gNight.Level = lvl
-	gNight.SunAngle = sa
+	gNight.BaseLevel = lvl
+	gNight.Azimuth = sa
 	gNight.Cloudy = cloudy
+	gNight.calcCurLevel()
 	gNight.mu.Unlock()
 	return true
+}
+
+var (
+	nightImg         *ebiten.Image
+	nightImgLevel    int
+	nightImgRedshift float64
+)
+
+func drawNightOverlay(screen *ebiten.Image) {
+	gNight.mu.Lock()
+	lvl := gNight.Level
+	gNight.mu.Unlock()
+	if lvl <= 0 {
+		return
+	}
+	redshift := 1.0
+	if nightImg == nil || nightImgLevel != lvl || nightImgRedshift != redshift {
+		rebuildNightOverlay(lvl, redshift)
+	}
+	op := &ebiten.DrawImageOptions{CompositeMode: ebiten.CompositeModeMultiply}
+	screen.DrawImage(nightImg, op)
+}
+
+func rebuildNightOverlay(level int, redshift float64) {
+	w := gameAreaSizeX * scale
+	h := gameAreaSizeY * scale
+	img := ebiten.NewImage(w, h)
+	lf := float64(level) / 100.0
+	rim := 1.0 - lf
+	center := rim
+	if lf >= 0.5 {
+		center = 0.5
+	}
+	cx := float64(w) / 2
+	cy := float64(h) / 2
+	radius := 325.0 * float64(scale)
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			dx := float64(x) - cx
+			dy := float64(y) - cy
+			t := math.Sqrt(dx*dx+dy*dy) / radius
+			if t > 1 {
+				t = 1
+			}
+			c := center*(1-t) + rim*t
+			r := c * redshift
+			if r > 1 {
+				r = 1
+			}
+			clr := color.RGBA{
+				R: uint8(r * 255),
+				G: uint8(c * 255),
+				B: uint8(c * 255),
+				A: 255,
+			}
+			img.Set(x, y, clr)
+		}
+	}
+	nightImg = img
+	nightImgLevel = level
+	nightImgRedshift = redshift
 }


### PR DESCRIPTION
## Summary
- parse night info messages and track lighting flags
- compute effective night level and render radial night gradient
- integrate night overlay into draw loop

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688e4fd21b08832a88761716bbc65537