### PR TITLE
Handle animated picture frames

### DIFF
--- a/go_client/climg/climg.go
+++ b/go_client/climg/climg.go
@@ -360,6 +360,24 @@ func (c *CLImages) NumFrames(id uint32) int {
 	return 1
 }
 
+// FrameIndex returns the picture frame for the given global animation counter.
+// If no animation is defined for the image, it returns 0.
+func (c *CLImages) FrameIndex(id uint32, counter int) int {
+	ref := c.idrefs[id]
+	if ref == nil || ref.numFrames <= 1 {
+		return 0
+	}
+	if ref.numAnims > 0 {
+		af := counter % int(ref.numAnims)
+		pf := int(ref.animFrameTable[af])
+		if pf >= 0 && pf < int(ref.numFrames) {
+			return pf
+		}
+		return 0
+	}
+	return counter % int(ref.numFrames)
+}
+
 // applyCustomPalette replaces entries in col according to mapping and custom.
 // mapping holds color table indices for each customizable slot while custom
 // provides the new palette indices supplied by the server for those slots.

--- a/go_client/game.go
+++ b/go_client/game.go
@@ -39,6 +39,7 @@ var interp bool
 var onion bool
 var linear bool
 var drawFilter = ebiten.FilterNearest
+var frameCounter int
 
 // drawState tracks information needed by the Ebiten renderer.
 type drawState struct {
@@ -191,6 +192,7 @@ func (g *Game) Update() error {
 		}
 	}
 
+	frameCounter++
 	return nil
 }
 
@@ -381,7 +383,11 @@ func drawPicture(screen *ebiten.Image, p framePicture, shiftX, shiftY int, alpha
 	offY := -float64(shiftY) * (1 - alpha)
 	x := (int(math.Round(float64(p.H)+offX)) + fieldCenterX) * scale
 	y := (int(math.Round(float64(p.V)+offY)) + fieldCenterY) * scale
-	if img := loadImage(p.PictID); img != nil {
+	frame := 0
+	if clImages != nil {
+		frame = clImages.FrameIndex(uint32(p.PictID), frameCounter)
+	}
+	if img := loadImageFrame(p.PictID, frame); img != nil {
 		op := &ebiten.DrawImageOptions{}
 		op.Filter = drawFilter
 		w, h := img.Bounds().Dx(), img.Bounds().Dy()

--- a/go_client/images.go
+++ b/go_client/images.go
@@ -15,9 +15,9 @@ import (
 // imageCache lazily loads images from the CL_Images archive. If an image is not
 // present, nil is cached to avoid repeated lookups.
 var (
-	// imageCache holds a cropped version of the first frame of an image. It
-	// is used for static pictures on the playfield.
-	imageCache = make(map[uint16]*ebiten.Image)
+	// imageCache holds cropped animation frames keyed by picture ID and
+	// frame index.
+	imageCache = make(map[string]*ebiten.Image)
 	// sheetCache holds the full sprite sheet for a picture ID and optional
 	// custom color palette. The key combines the picture ID with the custom
 	// color bytes so tinted versions are cached separately.
@@ -75,30 +75,45 @@ func loadSheet(id uint16, colors []byte) *ebiten.Image {
 // loadImage retrieves the first frame for the specified picture ID. Images are
 // cached after the first load to avoid reopening files each frame.
 func loadImage(id uint16) *ebiten.Image {
+	return loadImageFrame(id, 0)
+}
+
+// loadImageFrame retrieves a specific animation frame for the specified picture
+// ID. Frames are cached individually after the first load.
+func loadImageFrame(id uint16, frame int) *ebiten.Image {
+	key := fmt.Sprintf("%d-%d", id, frame)
 	imageMu.Lock()
-	if img, ok := imageCache[id]; ok {
+	if img, ok := imageCache[key]; ok {
 		imageMu.Unlock()
 		return img
 	}
 	imageMu.Unlock()
 
-	if sheet := loadSheet(id, nil); sheet != nil {
-		frames := clImages.NumFrames(uint32(id))
-		if frames > 1 {
-			h := sheet.Bounds().Dy() / frames
-			sheet = sheet.SubImage(image.Rect(0, 0, sheet.Bounds().Dx(), h)).(*ebiten.Image)
-		}
-		sheet = addBorder(sheet)
+	sheet := loadSheet(id, nil)
+	if sheet == nil {
 		imageMu.Lock()
-		imageCache[id] = sheet
+		imageCache[key] = nil
 		imageMu.Unlock()
-		return sheet
+		return nil
 	}
 
+	frames := 1
+	if clImages != nil {
+		frames = clImages.NumFrames(uint32(id))
+	}
+	if frames <= 0 {
+		frames = 1
+	}
+	frame = frame % frames
+	h := sheet.Bounds().Dy() / frames
+	y0 := frame * h
+	sub := sheet.SubImage(image.Rect(0, y0, sheet.Bounds().Dx(), y0+h)).(*ebiten.Image)
+	sub = addBorder(sub)
+
 	imageMu.Lock()
-	imageCache[id] = nil
+	imageCache[key] = sub
 	imageMu.Unlock()
-	return nil
+	return sub
 }
 
 // loadMobileFrame retrieves a cropped frame from a mobile sprite sheet based on


### PR DESCRIPTION
## Summary
- cache individual animation frames and compute current frame via CL_Images data
- track a global frame counter and use it when drawing pictures

## Testing
- `go build ./...`
- `xvfb-run -a go test ./...` *(fails: open test.clMov: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e4f59d6c4832ab82999957045a439